### PR TITLE
Read VIIRS thinning threshold from config and skip processing unreadable files

### DIFF
--- a/parm/config.hera.yaml
+++ b/parm/config.hera.yaml
@@ -16,7 +16,7 @@ obsforge:
 aoddump:
   provider: VIIRSAOD
   platforms: ['npp', 'n20', 'n21'] # note j01==n20
-  thinning_threshold: 0
+  thinning_threshold: 0.9931
   channel: 4
   preqc: 2
   WALLTIME_AOD_DUMP: '00:10:00'

--- a/parm/config.hercules.yaml
+++ b/parm/config.hercules.yaml
@@ -16,7 +16,7 @@ obsforge:
 aoddump:
   provider: VIIRSAOD
   platforms: ['npp', 'n20', 'n21'] # note j01==n20
-  thinning_threshold: 0
+  thinning_threshold: 0.9931
   channel: 4
   preqc: 2
   WALLTIME_AOD_DUMP: '00:10:00'

--- a/parm/config.wcoss2.yaml
+++ b/parm/config.wcoss2.yaml
@@ -16,7 +16,7 @@ obsforge:
 aoddump:
   provider: VIIRSAOD
   platforms: ['npp', 'j01', 'n21'] # note j01==n20
-  thinning_threshold: 0.9991
+  thinning_threshold: 0.9931
   channel: 4
   preqc: 2
   WALLTIME_AOD_DUMP: '00:10:00'

--- a/parm/config.wcoss2.yaml
+++ b/parm/config.wcoss2.yaml
@@ -16,7 +16,7 @@ obsforge:
 aoddump:
   provider: VIIRSAOD
   platforms: ['npp', 'j01', 'n21'] # note j01==n20
-  thinning_threshold: 0
+  thinning_threshold: 0.9991
   channel: 4
   preqc: 2
   WALLTIME_AOD_DUMP: '00:10:00'

--- a/ush/python/pyobsforge/task/aero_prepobs.py
+++ b/ush/python/pyobsforge/task/aero_prepobs.py
@@ -67,7 +67,7 @@ class AerosolObsPrep(Task):
                 context = {'provider': 'VIIRSAOD',
                            'window_begin': self.task_config.window_begin,
                            'window_end': self.task_config.window_end,
-                           'thinning_threshold': 0,
+                           'thinning_threshold': self.task_config.thinning_threshold,
                            'input_files': input_files,
                            'output_file': output_file}
                 result = run_nc2ioda(self.task_config, obs_space, context)

--- a/utils/preproc/Viirsaod2Ioda.h
+++ b/utils/preproc/Viirsaod2Ioda.h
@@ -17,6 +17,8 @@
 #include "NetCDFToIodaConverter.h"
 #include "superob.h"   // NOLINT
 
+using namespace netCDF::exceptions;
+
 namespace obsforge {
 
   class Viirsaod2Ioda : public NetCDFToIodaConverter {
@@ -30,10 +32,19 @@ namespace obsforge {
     obsforge::preproc::iodavars::IodaVars providerToIodaVars(const std::string fileName) final {
       oops::Log::info() << "Processing files provided by VIIRSAOD" << std::endl;
 
+      // Try to open the NetCDF file in read-only mode. If failed, return empty iodaVars object
+      try {
+        netCDF::NcFile ncFile(fileName, netCDF::NcFile::read);
+      } catch (const NcException &e) {
+        oops::Log::warning() << "Warning: Failed to read file " << fileName << ". Skipping." << std::endl;
+	oops::Log::warning() << e.what() << std::endl;
+	obsforge::preproc::iodavars::IodaVars iodaVars(0, {}, {});
+	return iodaVars;
+      }
+
       // Open the NetCDF file in read-only mode
       netCDF::NcFile ncFile(fileName, netCDF::NcFile::read);
       oops::Log::info() << "Reading... " << fileName << std::endl;
-
       // Get dimensions
       int dimRow = ncFile.getDim("Rows").getSize();
       int dimCol = ncFile.getDim("Columns").getSize();

--- a/utils/preproc/Viirsaod2Ioda.h
+++ b/utils/preproc/Viirsaod2Ioda.h
@@ -17,7 +17,7 @@
 #include "NetCDFToIodaConverter.h"
 #include "superob.h"   // NOLINT
 
-using namespace netCDF::exceptions;
+using netCDF::exceptions::NcException;
 
 namespace obsforge {
 
@@ -37,9 +37,9 @@ namespace obsforge {
         netCDF::NcFile ncFile(fileName, netCDF::NcFile::read);
       } catch (const NcException &e) {
         oops::Log::warning() << "Warning: Failed to read file " << fileName << ". Skipping." << std::endl;
-	oops::Log::warning() << e.what() << std::endl;
-	obsforge::preproc::iodavars::IodaVars iodaVars(0, {}, {});
-	return iodaVars;
+        oops::Log::warning() << e.what() << std::endl;
+        obsforge::preproc::iodavars::IodaVars iodaVars(0, {}, {});
+        return iodaVars;
       }
 
       // Open the NetCDF file in read-only mode


### PR DESCRIPTION
This PR 
1) enables the job to read the VIIRS AOD thinning threshold from `config.yaml` instead of being hard-coded. The threshold is temporarily set to `0.9931` to match the high-resolution (`C1152`) grid spacing (`~9 km`).
2) fixes the issue where execution stops when reading a broken obs file. The code now skips the broken file if it fails to read and continues processing the remaining files. 