### PR TITLE
Properly Ingesting amsr2 icec from changed latency

### DIFF
--- a/ush/python/pyobsforge/task/marine_prepobs.py
+++ b/ush/python/pyobsforge/task/marine_prepobs.py
@@ -144,6 +144,9 @@ class MarineObsPrep(Task):
             platform = "GW1"
             instrument = "AMSR2"
             satellite = "GW1"
+            # TODO(G,M): Get the window size from the config
+            window_begin = self.task_config.window_begin - timedelta(hours=24)
+            window_end = self.task_config.window_begin + timedelta(hours=6)
             kwargs = {
                 'provider': "amsr2",
                 'obs_space': obs_space,
@@ -152,8 +155,8 @@ class MarineObsPrep(Task):
                 'satellite': satellite,
                 'obs_type': obs_space,
                 'output_file': output_file,
-                'window_begin': self.task_config.window_begin,
-                'window_end': self.task_config.window_end,
+                'window_begin': window_begin,
+                'window_end': window_end,
                 'task_config': self.task_config
             }
             result = self.nesdis_amsr2.process_obs_space(**kwargs)

--- a/ush/python/pyobsforge/task/marine_prepobs.py
+++ b/ush/python/pyobsforge/task/marine_prepobs.py
@@ -145,7 +145,7 @@ class MarineObsPrep(Task):
             instrument = "AMSR2"
             satellite = "GW1"
             # TODO(G,M): Get the window size from the config
-            window_begin = self.task_config.window_begin - timedelta(hours=24)
+            window_begin = self.task_config.window_begin - timedelta(hours=30)
             window_end = self.task_config.window_begin + timedelta(hours=6)
             kwargs = {
                 'provider': "amsr2",


### PR DESCRIPTION
We've noticed that the timing of seeing `amsr2` seaice from `dcom` has been changed dramatically. Here is related issue (#59), we have contacted nesdis/obsproc people to see if timing comes back but this way is currently the best way to accommodate amsr2 seaice back to obsForge-

The testing a Realtime obsForge `(window to -24 and +6 Hrs)` shows that gfs cycle accommodates almost half cycle of it and gdas has had almost full cycle it self- (#82)

Later we will expect this window size will be controlled by config-

Close #59
Close #82