### PR TITLE
Adds multi-cycle window to bufr converter task

### DIFF
--- a/parm/bufr2ioda_template.yaml.j2
+++ b/parm/bufr2ioda_template.yaml.j2
@@ -3,12 +3,13 @@ subsets: {{ subsets }}
 source: {{ source }}
 data_type: {{ data_type }}
 cycle_type: {{ RUN }}
-cycle_datetime: "{{ current_cycle | to_YMDH }}"
+cycle_datetime: "{{ obs_cycle | to_YMDH }}"
 dump_directory: {{ DATA }}
 ioda_directory: {{ DATA }}
 ocean_basin: {{ ocean_basin }}
 data_description: {{ data_description}}
 data_provider: {{ data_provider }}
-dump_filename: "{{ RUN }}.{{ current_cycle | to_YMD }}/{{ cyc }}/atmos/{{ PREFIX }}{{ dump_tag }}.tm00.bufr_d"
-local_dump_filename: "{{ current_cycle | to_YMD }}{{ cyc }}-{{ PREFIX }}{{ dump_tag }}.tm00.bufr_d"
-ioda_filename: "{{RUN}}.t{{cyc}}z.{{name}}.{{ current_cycle | to_YMD }}{{ cyc }}.nc4"
+dump_filename: "{{ DMPDIR }}/{{ RUN }}.{{ obs_cycle | to_YMD }}/{{ obs_cycle_cyc }}/atmos/{{ obs_cycle_PREFIX }}{{ dump_tag }}.tm00.bufr_d"
+local_dump_filename: "{{ DATA }}/{{ obs_cycle | to_YMDH }}-{{ obs_cycle_PREFIX }}{{ dump_tag }}.tm00.bufr_d"
+ioda_filename: "{{RUN}}.t{{obs_cycle_cyc}}z.{{name}}.{{ obs_cycle | to_YMD }}{{ obs_cycle_cyc }}.nc4"
+bufr2ioda_yaml: "{{ DATA }}/{{ obs_cycle | to_YMDH }}-bufr2ioda_{{ name }}.yaml"

--- a/parm/bufr2ioda_template.yaml.j2
+++ b/parm/bufr2ioda_template.yaml.j2
@@ -9,6 +9,6 @@ ioda_directory: {{ DATA }}
 ocean_basin: {{ ocean_basin }}
 data_description: {{ data_description}}
 data_provider: {{ data_provider }}
-dump_filename: "{{ RUN }}.{{ yyyymmdd }}/{{ cyc }}/atmos/{{ PREFIX }}{{ dump_tag }}.tm00.bufr_d"
-local_dump_filename: "{{ yyyymmdd }}{{ cyc }}-{{ PREFIX }}{{ dump_tag }}.tm00.bufr_d"
-ioda_filename: "{{RUN}}.t{{cyc}}z.{{name}}.{{ yyyymmdd }}{{ cyc }}.nc4"
+dump_filename: "{{ RUN }}.{{ current_cycle | to_YMD }}/{{ cyc }}/atmos/{{ PREFIX }}{{ dump_tag }}.tm00.bufr_d"
+local_dump_filename: "{{ current_cycle | to_YMD }}{{ cyc }}-{{ PREFIX }}{{ dump_tag }}.tm00.bufr_d"
+ioda_filename: "{{RUN}}.t{{cyc}}z.{{name}}.{{ current_cycle | to_YMD }}{{ cyc }}.nc4"

--- a/parm/config.hercules.yaml
+++ b/parm/config.hercules.yaml
@@ -107,23 +107,109 @@ marinebufrdump:
   MEMORY_MARINE_BUFR_DUMP: 32GB
   BUFR2IODA_CONFIG_TEMP: 'bufr2ioda_template.yaml.j2'
   DMPDIR: /work/noaa/da/marineda/gfs-marine/data/obs/
+  ocean_basin: "/work2/noaa/global/role-global/fix/gdas/soca/20250519/common/RECCAP2_region_masks_all_v20221025.nc"
 
   providers:
     - name: insitu_profile_argo
       variables:
-        temp:
-          name: 'waterTemperature'
+        - name: 'waterTemperature'
           error: 0.02
-        salinity:
-          name: 'salinity'
+        - name: 'salinity'
           error: 0.01
       data_format: subpfl
       subsets: SUBPFL
       source: NCEP data tank
       data_type: argo
-      ocean_basin: " /work2/noaa/global/role-global/fix/gdas/soca/20250519/common/RECCAP2_region_masks_all_v20221025.nc"
       data_description: 6-hrly in situ ARGO profiles
       data_provider: U.S. NOAA
       dump_tag: subpfl
-
-
+      window:
+         back: 4
+         forward: 4
+    - name: insitu_profile_bathy
+      variables:
+        - name: 'waterTemperature'
+          error: 0.24
+      data_format: bathy
+      subsets: BATHY
+      source: NCEP data tank
+      data_type: bathy
+      data_description: 6-hrly in situ Bathythermal profiles
+      data_provider: U.S. NOAA
+      dump_tag: bathy
+    - name: insitu_profile_glider
+      variables:
+        - name: 'waterTemperature'
+          error: 0.02
+        - name: 'salinity'
+          error: 0.01
+      data_format: subpfl
+      subsets: SUBPFL
+      source: NCEP data tank
+      data_type: glider
+      data_description: 6-hrly in situ GLIDER profiles
+      data_provider: U.S. NOAA
+      dump_tag: glider  # apparently incorrect
+    - name: insitu_profile_tesac 
+      variables:
+        - name: 'waterTemperature'
+          error: 0.02
+        - name: 'salinity'
+          error: 0.01
+      data_format: tesac
+      subsets: TESAC
+      source: NCEP data tank
+      data_type: tesac
+      data_description: 6-hrly in situ TESAC profiles
+      data_provider: U.S. NOAA
+      dump_tag: tesac
+    - name: insitu_profile_tropical 
+      variables:
+        - name: 'waterTemperature'
+          error: 0.02
+        - name: 'salinity'
+          error: 0.01
+      data_format: dbuoy
+      subsets: dbuoy
+      source: NCEP data tank
+      data_type: tropical
+      data_description: 6-hrly in situ tropical mooring profiles
+      data_provider: U.S. NOAA
+      dump_tag: mbuoyb
+    - name: insitu_profile_xbtctd 
+      variables:
+        - name: 'waterTemperature'
+          error: 0.12
+        - name: 'salinity'
+          error: 1.0
+      data_format: xbtctd
+      subsets: XBTCTD
+      source: NCEP data tank
+      data_type: xbtctd
+      data_description: 6-hrly in situ XBT/XCTD profiles
+      data_provider: U.S. NOAA
+      dump_tag: xbtctd
+    - name: insitu_surface_drifter 
+      variables:
+        - name: 'waterTemperature'
+          error: 0.02
+      data_format: dbuoy
+      subsets: dbuoy
+      source: NCEP data tank
+      data_type: drifter
+      data_description: 6-hrly in situ drifter profiles
+      data_provider: U.S. NOAA
+      dump_tag: dbuoy
+    - name: insitu_surface_trkob
+      variables:
+        - name: 'seaSurfaceTemperature'
+          error: 0.3
+        - name: 'seaSurfaceSalinity'
+          error: 1.0
+      data_format: trkob
+      subsets: TRACKOB
+      source: NCEP data tank
+      data_type: trackob
+      data_description: 6-hrly in situ TRACKOB surface
+      data_provider: U.S. NOAA
+      dump_tag: trkob


### PR DESCRIPTION
Add ability to fetch multiple cycles of bufr obs, before or after the current cycle, convert them, and concatenate the resulting IODA files. Note: only the first variable for each provider in the task config is handled, this should probably be addressed at some point.


