### PR TITLE
Add trim function to datetime for AMSR2

### DIFF
--- a/utils/preproc/IcecAmsr2Ioda.h
+++ b/utils/preproc/IcecAmsr2Ioda.h
@@ -34,6 +34,15 @@ namespace obsforge {
     obsforge::preproc::iodavars::IodaVars providerToIodaVars(const std::string fileName) final {
       oops::Log::info() << "Processing files provided by the AMSR2" << std::endl;
 
+      //  Abort the case where the 'window begin & window end' key is not found
+      ASSERT(fullConfig_.has("window begin"));
+      ASSERT(fullConfig_.has("window end"));
+
+      // read as string
+      std::string windowBeginStr, windowEndStr;
+      fullConfig_.get("window begin", windowBeginStr);
+      fullConfig_.get("window end", windowEndStr);
+
       // Open the NetCDF file in read-only mode
       netCDF::NcFile ncFile(fileName, netCDF::NcFile::read);
       oops::Log::info() << "Reading... " << fileName << std::endl;
@@ -76,6 +85,18 @@ namespace obsforge {
       ncFile.getVar("Scan_Time").getVar(oneTmpdateTimeVal.data());
       iodaVars.referenceDate_ = "seconds since 1970-01-01T00:00:00Z";
 
+      // Set epoch time for AMSR2_ICEC
+      util::DateTime epochDtime("1970-01-01T00:00:00Z");
+
+      // Compute seconds of windowBegin and windowEnd since epoch
+      util::DateTime windowBegin(windowBeginStr);
+      util::DateTime windowEnd(windowEndStr);
+      int64_t winBeginsecondsSinceEpoch
+           = ioda::convertDtimeToTimeOffsets(epochDtime, {windowBegin})[0];
+      int64_t winEndsecondsSinceEpoch
+           = ioda::convertDtimeToTimeOffsets(epochDtime, {windowEnd})[0];
+
+      // Compute seconds of observations  since epoch
       size_t index = 0;
       for (int i = 0; i < ntimes; i += dimTimeSize) {
         int year = oneTmpdateTimeVal[i];
@@ -91,20 +112,7 @@ namespace obsforge {
           year = month = day = hour = minute = second = 0;
         }
 
-        // Construct iso8601 string format for each dateTime
-        std::stringstream ss;
-        ss << std::setfill('0')
-           << std::setw(4) << year << '-'
-           << std::setw(2) << month << '-'
-           << std::setw(2) << day << 'T'
-           << std::setw(2) << hour << ':'
-           << std::setw(2) << minute << ':'
-           << std::setw(2) << second << 'Z';
-        std::string formattedDateTime = ss.str();
-        util::DateTime dateTime(formattedDateTime);
-
-        // Set epoch time for AMSR2_ICEC
-        util::DateTime epochDtime("1970-01-01T00:00:00Z");
+        util::DateTime dateTime(year, month, day, hour, minute, second);
 
         // Convert Obs DateTime objects to epoch time offsets in seconds
         // 0000-00-00T00:00:00Z will be converterd to negative seconds
@@ -128,8 +136,10 @@ namespace obsforge {
       }
 
       // basic test for iodaVars.trim
-      Eigen::Array<bool, Eigen::Dynamic, 1> mask = (iodaVars.obsVal_ >= 0.0
-        && iodaVars.datetime_ > 0.0);
+      Eigen::Array<bool, Eigen::Dynamic, 1> mask =
+          (iodaVars.obsVal_ >= 0.0) &&
+          (iodaVars.datetime_ > winBeginsecondsSinceEpoch) &&
+          (iodaVars.datetime_ < winEndsecondsSinceEpoch);
       iodaVars.trim(mask);
 
       return iodaVars;


### PR DESCRIPTION
In the realtime obsForge, we need to look back 30 hrs ([currently](https://github.com/NOAA-EMC/obsForge/blob/c889752bee0bd0ce5a465eedda1fa15263e2bbe5/ush/python/pyobsforge/task/marine_prepobs.py#L148)) to ingest AMSR2 seaice concentration observation in gfs/gdas cycle since AMSR2 Sea Ice system has been migrated from NDE to NCCF (#59). However, by looking back/finding previous obs, a lot of observations that are not included in that cycle end up being processed.
So, this PR add the simple filter that trim unnecessary obs by 65~75%. As a result, the data could be trimmed to match the cycle.

Partially resolves : #91 

Examples are below;
`For 20250828 00Z`
```
--- Before ---
mindo.choi@clogin03:/lfs/h2/emc/da/noscrub/mindo.choi/MARINE_obs/COMROOT/realtime/gdas.20250828/00/ocean/icec> ncdump -h gdas.t00z.icec_amsr2_north.nc 
netcdf gdas.t00z.icec_amsr2_north {
dimensions:
        Location = 985015 ;
variables:
        int Location(Location) ;
                Location:suggested_chunk_dim = 985015LL ;
				
mindo.choi@clogin03:/lfs/h2/emc/da/noscrub/mindo.choi/come_back> python minNmax.py gdas.t00z.icec_amsr2_north.nc
[gdas.t00z.icec_amsr2_north.nc] Min dateTime: 1756222878 -> 2025-08-26 15:41:18
[gdas.t00z.icec_amsr2_north.nc] Max dateTime: 1756347485 -> 2025-08-28 02:18:05

--- After ---
(base) hercules-login-4[101] mindoc$ ncdump -h icec_amsr2_filtertest.ioda.nc
netcdf icec_amsr2_filtertest.ioda {
dimensions:
        Location = 302069 ;
variables:
        int Location(Location) ;
                Location:suggested_chunk_dim = 302069LL ;

(base) hercules-login-4[103] mindoc$ python3 minNmax.py icec_amsr2_filtertest.ioda.nc
[icec_amsr2_filtertest.ioda.nc] Min dateTime: 1756328597 -> 2025-08-27 21:03:17
[icec_amsr2_filtertest.ioda.nc] Max dateTime: 1756347485 -> 2025-08-28 02:18:05
```
`For 20250828 06Z`
```
--- Before ---
mindo.choi@clogin02:/lfs/h2/emc/da/noscrub/mindo.choi/MARINE_obs/COMROOT/realtime/gdas.20250828/06/ocean/icec> ncdump -h gdas.t06z.icec_amsr2_north.nc 
netcdf gdas.t06z.icec_amsr2_north {
dimensions:
        Location = 1153385 ;
variables:
        int Location(Location) ;
                Location:suggested_chunk_dim = 1153385LL ;
				
mindo.choi@clogin02:/lfs/h2/emc/da/noscrub/mindo.choi/MARINE_obs/COMROOT/realtime/gdas.20250828/06/ocean/icec> python3 minNmax.py gdas.t06z.icec_amsr2_north.nc 
[gdas.t06z.icec_amsr2_north.nc] Min dateTime: 1756252947 -> 2025-08-27 00:02:27
[gdas.t06z.icec_amsr2_north.nc] Max dateTime: 1756370884 -> 2025-08-28 08:48:04

--- After ---
(base) hercules-login-4[115] mindoc$ ncdump -h icec_amsr2_filtertest2.ioda.nc
netcdf icec_amsr2_filtertest2.ioda {
dimensions:
        Location = 250597 ;
variables:
        int Location(Location) ;
                Location:suggested_chunk_dim = 250597LL ;
				
(base) hercules-login-4[114] mindoc$ python minNmax.py icec_amsr2_filtertest2.ioda.nc
[icec_amsr2_filtertest2.ioda.nc] Min dateTime: 1756352425 -> 2025-08-28 03:40:25
[icec_amsr2_filtertest2.ioda.nc] Max dateTime: 1756370884 -> 2025-08-28 08:48:04
```