### PR TITLE
Add trim function to datetime for AMSR2 icec

### DIFF
--- a/utils/preproc/IcecAmsr2Ioda.h
+++ b/utils/preproc/IcecAmsr2Ioda.h
@@ -34,6 +34,15 @@ namespace obsforge {
     obsforge::preproc::iodavars::IodaVars providerToIodaVars(const std::string fileName) final {
       oops::Log::info() << "Processing files provided by the AMSR2" << std::endl;
 
+      //  Abort the case where the 'window begin & window end' key is not found
+      ASSERT(fullConfig_.has("window begin"));
+      ASSERT(fullConfig_.has("window end"));
+
+      // read as string
+      std::string windowBeginStr, windowEndStr;
+      fullConfig_.get("window begin", windowBeginStr);
+      fullConfig_.get("window end", windowEndStr);
+
       // Open the NetCDF file in read-only mode
       netCDF::NcFile ncFile(fileName, netCDF::NcFile::read);
       oops::Log::info() << "Reading... " << fileName << std::endl;
@@ -76,9 +85,19 @@ namespace obsforge {
       ncFile.getVar("Scan_Time").getVar(oneTmpdateTimeVal.data());
       iodaVars.referenceDate_ = "seconds since 1970-01-01T00:00:00Z";
 
-      size_t index = 0;
       // Set epoch time for AMSR2_ICEC
       util::DateTime epochDtime("1970-01-01T00:00:00Z");
+
+      // Compute seconds of windowBegin and windowEnd since epoch
+      util::DateTime windowBegin(windowBeginStr);
+      util::DateTime windowEnd(windowEndStr);
+      int64_t winBeginsecondsSinceEpoch
+           = ioda::convertDtimeToTimeOffsets(epochDtime, {windowBegin})[0];
+      int64_t winEndsecondsSinceEpoch
+           = ioda::convertDtimeToTimeOffsets(epochDtime, {windowEnd})[0];
+
+      // Compute seconds of observations  since epoch
+      size_t index = 0;
       for (int i = 0; i < ntimes; i += dimTimeSize) {
         int year = oneTmpdateTimeVal[i];
         int month = oneTmpdateTimeVal[i+1];
@@ -117,8 +136,10 @@ namespace obsforge {
       }
 
       // basic test for iodaVars.trim
-      Eigen::Array<bool, Eigen::Dynamic, 1> mask = (iodaVars.obsVal_ >= 0.0
-        && iodaVars.datetime_ > 0.0);
+      Eigen::Array<bool, Eigen::Dynamic, 1> mask =
+          (iodaVars.obsVal_ >= 0.0) &&
+          (iodaVars.datetime_ > winBeginsecondsSinceEpoch) &&
+          (iodaVars.datetime_ < winEndsecondsSinceEpoch);
       iodaVars.trim(mask);
 
       return iodaVars;

--- a/utils/preproc/IcecAmsr2Ioda.h
+++ b/utils/preproc/IcecAmsr2Ioda.h
@@ -138,8 +138,8 @@ namespace obsforge {
       // basic test for iodaVars.trim
       Eigen::Array<bool, Eigen::Dynamic, 1> mask =
           (iodaVars.obsVal_ >= 0.0) &&
-          (iodaVars.datetime_ > winBeginSecondsSinceEpoch) &&
-          (iodaVars.datetime_ < winEndSecondsSinceEpoch);
+          (iodaVars.datetime_ >= winBeginSecondsSinceEpoch) &&
+          (iodaVars.datetime_ <= winEndSecondsSinceEpoch);
       iodaVars.trim(mask);
 
       return iodaVars;

--- a/utils/preproc/IcecAmsr2Ioda.h
+++ b/utils/preproc/IcecAmsr2Ioda.h
@@ -91,9 +91,9 @@ namespace obsforge {
       // Compute seconds of windowBegin and windowEnd since epoch
       util::DateTime windowBegin(windowBeginStr);
       util::DateTime windowEnd(windowEndStr);
-      int64_t winBeginsecondsSinceEpoch
+      int64_t winBeginSecondsSinceEpoch
            = ioda::convertDtimeToTimeOffsets(epochDtime, {windowBegin})[0];
-      int64_t winEndsecondsSinceEpoch
+      int64_t winEndSecondsSinceEpoch
            = ioda::convertDtimeToTimeOffsets(epochDtime, {windowEnd})[0];
 
       // Compute seconds of observations  since epoch
@@ -138,8 +138,8 @@ namespace obsforge {
       // basic test for iodaVars.trim
       Eigen::Array<bool, Eigen::Dynamic, 1> mask =
           (iodaVars.obsVal_ >= 0.0) &&
-          (iodaVars.datetime_ > winBeginsecondsSinceEpoch) &&
-          (iodaVars.datetime_ < winEndsecondsSinceEpoch);
+          (iodaVars.datetime_ > winBeginSecondsSinceEpoch) &&
+          (iodaVars.datetime_ < winEndSecondsSinceEpoch);
       iodaVars.trim(mask);
 
       return iodaVars;

--- a/utils/test/testref/icecamsr2ioda.test
+++ b/utils/test/testref/icecamsr2ioda.test
@@ -3,24 +3,24 @@ seconds since 1970-01-01T00:00:00Z
 obsVal:
     Min: 0
     Max: 1
-    Sum: 11.91
+    Sum: 7.97
 obsError:
     Min: 0.1
     Max: 0.1
-    Sum: 1.7
+    Sum: 1
 preQc:
     Min: 0
     Max: 8
-    Sum: 40
+    Sum: 16
 longitude:
     Min: -168.867
     Max: 148.766
-    Sum: -302.819
+    Sum: -4.245
 latitude:
-    Min: 72.8259
-    Max: 86.8975
-    Sum: 1346.66
+    Min: 74.1823
+    Max: 82.8885
+    Sum: 786.105
 datetime:
-    Min: 1625048557
+    Min: 1625090122
     Max: 1625108209
-    Sum: 27626462899
+    Sum: 16251003302


### PR DESCRIPTION
In the realtime obsForge, we need to look back 30 hrs ([currently](https://github.com/NOAA-EMC/obsForge/blob/c889752bee0bd0ce5a465eedda1fa15263e2bbe5/ush/python/pyobsforge/task/marine_prepobs.py#L148)) to ingest AMSR2 seaice concentration observation in gfs/gdas cycle since AMSR2 Sea Ice system has been migrated from NDE to NCCF (#59). However, by looking back/finding previous obs, a lot of observations that are not included in that cycle end up being processed.
So, this PR add the simple filter that trim unnecessary obs by 65~75%. As a result, the data could be trimmed to match the cycle.

Partially resolves : #91 

Examples are below;
`For 20250828 00Z`
```
--- Before ---
mindo.choi@clogin03:/lfs/h2/emc/da/noscrub/mindo.choi/MARINE_obs/COMROOT/realtime/gdas.20250828/00/ocean/icec> ncdump -h gdas.t00z.icec_amsr2_north.nc 
netcdf gdas.t00z.icec_amsr2_north {
dimensions:
        Location = 985015 ;
variables:
        int Location(Location) ;
                Location:suggested_chunk_dim = 985015LL ;
				
mindo.choi@clogin03:/lfs/h2/emc/da/noscrub/mindo.choi/come_back> python minNmax.py gdas.t00z.icec_amsr2_north.nc
[gdas.t00z.icec_amsr2_north.nc] Min dateTime: 1756222878 -> 2025-08-26 15:41:18
[gdas.t00z.icec_amsr2_north.nc] Max dateTime: 1756347485 -> 2025-08-28 02:18:05

--- After ---
(base) hercules-login-4[101] mindoc$ ncdump -h icec_amsr2_filtertest.ioda.nc
netcdf icec_amsr2_filtertest.ioda {
dimensions:
        Location = 302069 ;
variables:
        int Location(Location) ;
                Location:suggested_chunk_dim = 302069LL ;

(base) hercules-login-4[103] mindoc$ python3 minNmax.py icec_amsr2_filtertest.ioda.nc
[icec_amsr2_filtertest.ioda.nc] Min dateTime: 1756328597 -> 2025-08-27 21:03:17
[icec_amsr2_filtertest.ioda.nc] Max dateTime: 1756347485 -> 2025-08-28 02:18:05
```
`For 20250828 06Z`
```
--- Before ---
mindo.choi@clogin02:/lfs/h2/emc/da/noscrub/mindo.choi/MARINE_obs/COMROOT/realtime/gdas.20250828/06/ocean/icec> ncdump -h gdas.t06z.icec_amsr2_north.nc 
netcdf gdas.t06z.icec_amsr2_north {
dimensions:
        Location = 1153385 ;
variables:
        int Location(Location) ;
                Location:suggested_chunk_dim = 1153385LL ;
				
mindo.choi@clogin02:/lfs/h2/emc/da/noscrub/mindo.choi/MARINE_obs/COMROOT/realtime/gdas.20250828/06/ocean/icec> python3 minNmax.py gdas.t06z.icec_amsr2_north.nc 
[gdas.t06z.icec_amsr2_north.nc] Min dateTime: 1756252947 -> 2025-08-27 00:02:27
[gdas.t06z.icec_amsr2_north.nc] Max dateTime: 1756370884 -> 2025-08-28 08:48:04

--- After ---
(base) hercules-login-4[115] mindoc$ ncdump -h icec_amsr2_filtertest2.ioda.nc
netcdf icec_amsr2_filtertest2.ioda {
dimensions:
        Location = 250597 ;
variables:
        int Location(Location) ;
                Location:suggested_chunk_dim = 250597LL ;
				
(base) hercules-login-4[114] mindoc$ python minNmax.py icec_amsr2_filtertest2.ioda.nc
[icec_amsr2_filtertest2.ioda.nc] Min dateTime: 1756352425 -> 2025-08-28 03:40:25
[icec_amsr2_filtertest2.ioda.nc] Max dateTime: 1756370884 -> 2025-08-28 08:48:04
```