### PR TITLE
Process ocean_basin flag correctly using proper YAML configuration

### DIFF
--- a/ush/python/pyobsforge/task/providers.py
+++ b/ush/python/pyobsforge/task/providers.py
@@ -49,9 +49,10 @@ class QCConfig:
 
 
 class ProviderConfig:
-    def __init__(self, qc_config: QCConfig, db: Any):  # Replace `Any` with a more specific type if desired
+    def __init__(self, qc_config: QCConfig, db: Any, ocean_basin: Any = None):  # Replace `Any` with a more specific type if desired
         self.qc_config = qc_config
         self.db = db
+        self.ocean_basin = ocean_basin
 
     @classmethod
     def from_task_config(cls, provider_name: str, task_config: AttrDict) -> "ProviderConfig":
@@ -84,7 +85,8 @@ class ProviderConfig:
         else:
             raise NotImplementedError(f"DB setup for provider {provider_name} not yet implemented")
 
-        return cls(qc_config=qc, db=db)
+        ocean_basin = getattr(task_config, "ocean_basin", None)
+        return cls(qc_config=qc, db=db, ocean_basin=ocean_basin)
 
     def process_obs_space(self, **kwargs) -> None:
         """
@@ -131,6 +133,10 @@ class ProviderConfig:
                        'window_end': window_end,
                        'input_files': input_files,
                        'output_file': output_file}
+
+            # Add global ocean_basin if present
+            if getattr(self, "ocean_basin", None):
+                context["ocean_basin"] = self.ocean_basin
 
             # Only add QC config attributes if they exist
             if hasattr(self.qc_config, 'bounds_min'):


### PR DESCRIPTION
As the title says, fix `ocean_basin` flag handling: read from YAML config instead of defaulting to `-999`.

Resolves : #76 
Maybe : #104 

Sample yaml like below;

```
provider: RADS
window begin: '2024-08-28T21:00:00Z'
window end: '2024-09-03T21:00:00Z'
output file: gdas.t00z.rads_adt_3a.nc
binning:
  stride: 0.0
  min number of obs: 0
bounds:
  min: -2.0
  max: 3.0
ocean basin: /scratch3/NCEPDEV/da/common/validation/RECCAP2_region_masks_all_v20221025.nc
input files:
- rads_adt_3a/rads_adt_3a_2024247.nc
- rads_adt_3a/rads_adt_3a_2024242.nc
- rads_adt_3a/rads_adt_3a_2024244.nc
- rads_adt_3a/rads_adt_3a_2024246.nc
- rads_adt_3a/rads_adt_3a_2024243.nc
- rads_adt_3a/rads_adt_3a_2024245.nc
error ratio: 1.0
```