### PR TITLE
Update dependency in gfs/gdas xml

### DIFF
--- a/parm/gdas_realtime.xml.j2
+++ b/parm/gdas_realtime.xml.j2
@@ -162,9 +162,11 @@
 	<envar><name>DCOMROOT</name><value>{{ DCOMROOT }}</value></envar>
 	<envar><name>DATAROOT</name><value>{{ DATAROOT }}/{{ PSLOT }}/gdas.<cyclestr>@Y@m@d@H</cyclestr></value></envar>
 
-        <dependency>
-                <datadep><cyclestr>/lfs/h2/emc/obsproc/noscrub/iliana.genkova/CRON/SOCA/com/obsproc/v1.2/gdas.@Y@m@d/@H/atmos/gdas.t@Hz.subpfl.tm00.bufr_d</cyclestr></datadep>
+        <!--dependency>
+                <datadep><cyclestr>/lfs/h1/ops/prod/com/obsproc/v1.2/gdas.@Y@m@d/@H/atmos/gdas.t@Hz.updated.status.tm00.bufr_d</cyclestr></datadep>
 	</dependency>
+	-->
+			
 
 </task>
 

--- a/parm/gfs_realtime.xml.j2
+++ b/parm/gfs_realtime.xml.j2
@@ -123,8 +123,8 @@
 	<envar><name>DATAROOT</name><value>{{ DATAROOT }}/{{ PSLOT }}/gfs.<cyclestr>@Y@m@d@H</cyclestr></value></envar>
 
 	<!--dependency>
-                <datadep><cyclestr>/lfs/h2/emc/obsproc/noscrub/iliana.genkova/CRON/SOCA/com/obsproc/v1.2/gfs.@Y@m@d/@H/atmos/gfs.t@Hz.subpfl.tm00.bufr_d</cyclestr></datadep>
-	</dependency>
+                <datadep><cyclestr>/lfs/h1/ops/prod/com/obsproc/v1.2/gfs.@Y@m@d/@H/atmos/gfs.t@Hz.updated.status.tm00.bufr_d</cyclestr></datadep>
+        </dependency>
         -->
 
 </task>


### PR DESCRIPTION
This PR removes the dependency on Iliana’s cron in the obsForge real-time XML templates (GFS & GDAS) and adds the obsproc location for use when #120 is available.

Closed #133