### PR TITLE
Check if the created ioda file is a valid hdf5/netcdf4 file

### DIFF
--- a/ush/python/pyobsforge/task/marine_bufr_prepobs.py
+++ b/ush/python/pyobsforge/task/marine_bufr_prepobs.py
@@ -199,7 +199,13 @@ class MarineBufrObsPrep(Task):
                 source_ioda_filename = path.join(self.task_config.DATA, ioda_filename)
                 if path.exists(source_ioda_filename):
                     destination_ioda_filename = path.join(self.task_config.COMIN_OBSPROC, concat_config['save file'])
-                    ioda_files_to_copy.append([source_ioda_filename, destination_ioda_filename])
+                    # Only append if source_ioda_filename is a valid NetCDF4 file
+                    try:
+                        with netCDF4.Dataset(source_ioda_filename, 'r'):
+                            src_dst_obs_list.append([source_ioda_filename, destination_ioda_filename])
+                    except Exception:
+                        logger.warning(f"Skipping invalid file: {source_ioda_filename}")
+                        ioda_files_to_copy.append([source_ioda_filename, destination_ioda_filename])
 
         FileHandler({'copy_opt': ioda_files_to_copy}).sync()
 

--- a/ush/python/pyobsforge/task/marine_bufr_prepobs.py
+++ b/ush/python/pyobsforge/task/marine_bufr_prepobs.py
@@ -17,6 +17,7 @@ from wxflow import (
     parse_yaml,
     save_as_yaml,
 )
+import netCDF4
 
 logger = getLogger(__name__.split('.')[-1])
 
@@ -202,10 +203,9 @@ class MarineBufrObsPrep(Task):
                     # Only append if source_ioda_filename is a valid NetCDF4 file
                     try:
                         with netCDF4.Dataset(source_ioda_filename, 'r'):
-                            src_dst_obs_list.append([source_ioda_filename, destination_ioda_filename])
+                            ioda_files_to_copy.append([source_ioda_filename, destination_ioda_filename])
                     except Exception:
                         logger.warning(f"Skipping invalid file: {source_ioda_filename}")
-                        ioda_files_to_copy.append([source_ioda_filename, destination_ioda_filename])
 
         FileHandler({'copy_opt': ioda_files_to_copy}).sync()
 

--- a/ush/python/pyobsforge/task/marine_prepobs.py
+++ b/ush/python/pyobsforge/task/marine_prepobs.py
@@ -10,6 +10,7 @@ from datetime import timedelta
 import glob
 from os.path import basename
 import pathlib
+import netCDF4
 
 logger = getLogger(__name__.split('.')[-1])
 
@@ -273,7 +274,12 @@ class MarineObsPrep(Task):
                 logger.info(f"ioda_file: {ioda_file}")
                 src_file = ioda_file
                 dst_file = join(comout_tmp, basename(ioda_file))
-                src_dst_obs_list.append([src_file, dst_file])
+                # Only append if src_file is a valid NetCDF4 file
+                try:
+                    with netCDF4.Dataset(src_file, 'r'):
+                        src_dst_obs_list.append([src_file, dst_file])
+                except Exception:
+                    logger.warning(f"Skipping invalid file: {src_file}")
 
         logger.info("Copying ioda files to destination COMROOT directory")
         logger.info(f"src_dst_obs_list: {src_dst_obs_list}")


### PR DESCRIPTION
This does not cover all the failure modes, but it will catch some, like the `smap` error recently encountered.

