### PR TITLE
update coding norms for spoc: obsForge_coding_norms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ add_subdirectory(test)
 ecbuild_add_test( TARGET ${PROJECT_NAME}_coding_norms
                   TYPE SCRIPT
                   COMMAND ${PROJECT_NAME}_py_lint.sh
-                  ARGS ${CMAKE_CURRENT_SOURCE_DIR}/sorc/spoc/dump/mapping ${CMAKE_CURRENT_SOURCE_DIR}
+                  ARGS ${CMAKE_CURRENT_SOURCE_DIR}/sorc/spoc/dump/scripts ${CMAKE_CURRENT_SOURCE_DIR}
                   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin )
 set_tests_properties( ${PROJECT_NAME}_coding_norms PROPERTIES TIMEOUT 90 )
 


### PR DESCRIPTION
The ctest for obsForge_coding_norms was failing due to the path being changed. This PR updates that path.
Fixes #148 

- [x] Change path
- [x] build
- [x] test
- [x] test succeeds