### PR TITLE
Separate search window and DA window for RADS YAML generation

### DIFF
--- a/ush/python/pyobsforge/task/providers.py
+++ b/ush/python/pyobsforge/task/providers.py
@@ -120,7 +120,7 @@ class ProviderConfig:
 
         # YAML window (always DA window)
         yaml_window_begin = task_config.window_begin
-        yaml_window_end   = task_config.window_end
+        yaml_window_end = task_config.window_end
 
         # Query the database for valid files
         input_files = self.db.get_valid_files(window_begin=search_window_begin,


### PR DESCRIPTION
## Summary

This PR fixes an issue where `window_begin` and `window_end` were incorrectly shared between the `DCOM` database query and the YAML configuration passed to the IODA converter. Previously, both stages used the expanded ±72-hour search window, causing the generated YAML to contain incorrect time windows.

## Problem

For certain providers (e.g., RADS), the workflow intentionally expands the search window (±72 hours) to locate all available input files in DCOM. However, this same expanded window was being passed directly into the YAML context, which resulted in:

- Incorrect `window_begin` / `window_end` values in the generated YAML  
- `redate` logic not being applied correctly so that wrong assimilation window for cycles

## Fix Implemented

This PR separates the **search window** from the **assimilation (YAML) window**, ensuring that each component receives the appropriate values:

- **Database lookup (`get_valid_files`)**
  - Continues using the wider ±72-hour window for RADS (or whatever the caller provides) to discover input files.

- **IODA YAML generation**
  - Now always uses `task_config.window_begin` and `task_config.window_end`.
  - Correctly reflects the DA window used for assimilation.
  - Ensures proper `redate` behavior and correct application of the window for `20251114 00Z`.

## Result

- YAML files now contain the **correct DA window**, not the expanded search window.
- File discovery behavior remains unchanged and continues to work for providers requiring an extended time search window.
- Cycle windows (e.g., `20251114 00Z`) are now applied correctly and consistently across the system.

## Additional Notes

- No changes were made to QC, `ocean_basin`, or file-copy logic.
- Behavior for non-RADS providers remains unchanged.
- This refactor clarifies the separation of responsibilities between:
  - time windows used for **file search**, and  
  - time windows used for **assimilation/YAML configuration**.

Fixes: #164 