### PR TITLE
added depth check to all bufr2ioda converters

### DIFF
--- a/utils/b2i/b2iconverter/ioda_variables.py
+++ b/utils/b2i/b2iconverter/ioda_variables.py
@@ -94,7 +94,11 @@ class IODAVariables:
 
     def filter(self):
         mask = clean_lat_lon(self.metadata.lat, self.metadata.lon)
+        if hasattr(self.metadata, 'depth'):
+            depth_mask = clean_depth(self.metadata.depth)
+            mask = mask & depth_mask
         self.metadata.filter(mask)
+
         if hasattr(self, 'temp'):
             self.temp = self.temp[mask]
         if hasattr(self, 'saln'):

--- a/utils/b2i/b2iconverter/util.py
+++ b/utils/b2i/b2iconverter/util.py
@@ -158,6 +158,34 @@ def clean_lat_lon(lat, lon):
     mask &= ~np.isnan(lon)
 
     return mask
+
+
+def clean_depth(depth, min_depth=0.0, max_depth=11000.0):
+    """
+    Returns a boolean mask for valid depth values.
+
+    Parameters
+    ----------
+    depth : array-like or masked array
+        Depth values (meters, positive down).
+    min_depth : float
+        Minimum acceptable depth.
+    max_depth : float
+        Maximum acceptable depth.
+
+    Returns
+    -------
+    mask : np.ndarray (bool)
+        True where depth is valid.
+    """
+    depth = np.asarray(depth)
+
+    mask = np.isfinite(depth)
+    mask &= depth >= min_depth
+    mask &= depth <= max_depth
+
+    return mask
+
 #####################################################################
 
 


### PR DESCRIPTION
the default values are between 0 and 11,000
All other values are filtered out.

closes https://github.com/NOAA-EMC/obsForge/issues/174