### PR TITLE
Update MetaData Variables in in-situ Concatenator

### DIFF
--- a/utils/preproc/InsituAll2ioda.h
+++ b/utils/preproc/InsituAll2ioda.h
@@ -103,17 +103,17 @@ namespace obsforge {
       rcptdateTimeVar.getVar(rcptdateTimeData.data());
 
       netCDF::NcVar stationIDVar = metaDataGroup.getVar("stationID");
-      std::vector<int> stationIDData(iodaVars.location_, -999); // Initialize with default = -999
+      std::vector<int> stationIDData(iodaVars.location_, -999);  // Initialize with default = -999
 
       // Only accept NC_INT (Currently argo, glider and xbtctd)
       if (!stationIDVar.isNull() &&
           stationIDVar.getType().getTypeClass() == netCDF::NcType::nc_INT) {
-	      oops::Log::info() << "Variable 'stationID' is int; reading it." << std::endl;
-	      stationIDVar.getVar(stationIDData.data());
+              oops::Log::info() << "Variable 'stationID' is int; reading it." << std::endl;
+              stationIDVar.getVar(stationIDData.data());
       } else {
       // keep default -999 if data type is string
       oops::Log::debug()
-	  << "MetaData/stationID is not int (or string). Using default -999."
+          << "MetaData/stationID is not int (or string). Using default -999."
           << std::endl;
       }
 


### PR DESCRIPTION
## Summary

This PR include more handling of `MetaData/stationID` and `MetaData/rcptdateTime` in In-situ concatenator.

## What Implemented

- Added robust handling for `MetaData/stationID` where the variable can appear as either string or int depending on the provider/file.
- Keep `-999` and log a debug message if `stationID` is string (or missing/other type).
- Only attempt to read `stationID` when the NetCDF type is NC_INT (e.g., Argo/Glider/XBTCTD cases).
- This prevents NetCDF read failures caused by string vs int mismatches while preserving numeric IDs where available.

## Additional Notes

StationIDs here are defined below;
- For Argo  : WMO Identifier
- For Glider: IOOS National Glider Data Assembly Center (NGDAC)
...