### PR TITLE
Concatenate other marine profiles

### DIFF
--- a/parm/marine_bufr_dump_config.yaml
+++ b/parm/marine_bufr_dump_config.yaml
@@ -34,6 +34,9 @@ marinebufrdump:
       data_description: 6-hrly in situ Bathythermal profiles
       data_provider: U.S. NOAA
       dump_tag: bathy
+      window:
+         back: 4
+         forward: 4
 
     - name: insitu_profile_glider
       variables:
@@ -50,6 +53,9 @@ marinebufrdump:
       data_description: 6-hrly in situ GLIDER profiles
       data_provider: U.S. NOAA
       dump_tag: subpfl
+      window:
+         back: 4
+         forward: 4
 
     - name: insitu_profile_tesac 
       variables:
@@ -66,6 +72,9 @@ marinebufrdump:
       data_description: 6-hrly in situ TESAC profiles
       data_provider: U.S. NOAA
       dump_tag: tesac
+      window:
+         back: 4
+         forward: 4
 
     - name: insitu_profile_rama 
       variables:
@@ -130,6 +139,9 @@ marinebufrdump:
       data_description: 6-hrly in situ XBT/XCTD profiles
       data_provider: U.S. NOAA
       dump_tag: xbtctd
+      window:
+         back: 4
+         forward: 4
 
     - name: insitu_surface_dbuoyb_drifter
       variables:

--- a/ush/python/pyobsforge/task/marine_bufr_prepobs.py
+++ b/ush/python/pyobsforge/task/marine_bufr_prepobs.py
@@ -145,7 +145,7 @@ class MarineBufrObsPrep(Task):
                     'window begin': self.task_config['window_begin'],
                     'window end': self.task_config['window_end'],
                     'variable': variable['name'],
-                    # Ratio below is for concatination only
+                    # Ratio below is for concatenation only
                     'error ratio': 0.4,
                     'input files': ioda_files_to_concat,
                     'output file': f"{RUN}.t{cycstr}z.{provider_var}.{self.task_config.yyyymmdd}{cycstr}.concat.nc",

--- a/ush/python/pyobsforge/task/marine_bufr_prepobs.py
+++ b/ush/python/pyobsforge/task/marine_bufr_prepobs.py
@@ -145,7 +145,7 @@ class MarineBufrObsPrep(Task):
                     'window begin': self.task_config['window_begin'],
                     'window end': self.task_config['window_end'],
                     'variable': variable['name'],
-                    # error ratio below is for concatinate 
+                    # Ratio below is for concatination only
                     'error ratio': 0.4,
                     'input files': ioda_files_to_concat,
                     'output file': f"{RUN}.t{cycstr}z.{provider_var}.{self.task_config.yyyymmdd}{cycstr}.concat.nc",

--- a/ush/python/pyobsforge/task/marine_bufr_prepobs.py
+++ b/ush/python/pyobsforge/task/marine_bufr_prepobs.py
@@ -145,6 +145,7 @@ class MarineBufrObsPrep(Task):
                     'window begin': self.task_config['window_begin'],
                     'window end': self.task_config['window_end'],
                     'variable': variable['name'],
+                    # error ratio below is for concatinate 
                     'error ratio': 0.4,
                     'input files': ioda_files_to_concat,
                     'output file': f"{RUN}.t{cycstr}z.{provider_var}.{self.task_config.yyyymmdd}{cycstr}.concat.nc",


### PR DESCRIPTION
This PR includes;

- Concatenate other profiles other than Argo and exclude pirata, rama and taotrition
- Add comments for ratio of concatenation
- Sets +- 4 cycles to all for now
- Initial `ObsError` has been set from `Bufr2Ioda Converter`, example for Argo [here](https://github.com/NOAA-EMC/obsForge/blob/4c3a58f753cc40fb07e23283e66e7962ce449a63/utils/b2i/bufr2ioda_insitu_profile_argo.py#L29), meaning that errors in config do not work in each converters, [example](https://github.com/NOAA-EMC/obsForge/blob/4c3a58f753cc40fb07e23283e66e7962ce449a63/parm/marine_bufr_dump_config.yaml#L10), because of obserror that is hard-coded.

Closes : #198 