### PR TITLE
Update atmos_bufr_prepobs.py for restriction logic

### DIFF
--- a/ush/python/pyobsforge/task/aero_prepobs.py
+++ b/ush/python/pyobsforge/task/aero_prepobs.py
@@ -125,7 +125,7 @@ class AerosolObsPrep(Task):
             'output file': str(ready_file),
         }
         save_as_yaml(summary_dict, os.path.join(self.task_config.DATA, "stats.yaml"))
-        exec_cmd = Executable(os.path.join(self.task_config.HOMEobsforge, "build", "bin", "ioda-dump.x"))
+        exec_cmd = Executable(os.path.join(self.task_config.HOMEobsforge, "build", "bin", "ioda-summary.x"))
         exec_cmd.add_default_arg(os.path.join(self.task_config.DATA, "stats.yaml"))
         try:
             logger.info(f"Creating summary file {ready_file}")

--- a/ush/python/pyobsforge/task/atmos_bufr_prepobs.py
+++ b/ush/python/pyobsforge/task/atmos_bufr_prepobs.py
@@ -266,3 +266,23 @@ class AtmosBufrObsPrep(Task):
             logger.warning(f"Failed to create summary file {ready_file}: {e}")
             logger.warning("Creating an empty ready file instead")
             ready_file.touch()
+
+        # Run unified restriction filter AFTER finalize
+        stats_yaml = os.path.join(self.task_config.DATA, "stats.yaml")
+
+        script_path = os.path.join(
+            self.task_config.HOMEobsforge, "build", "bin", "ioda_restriction_filter.py"
+        )
+
+        logger.info(f"Running unified restriction filter using {stats_yaml}")
+
+        exec_cmd = Executable("python")
+        exec_cmd.add_default_arg(script_path)
+        exec_cmd.add_default_arg("--stats")
+        exec_cmd.add_default_arg(stats_yaml)
+
+        try:
+            exec_cmd()
+        except Exception as e:
+            logger.warning(f"ioda_restriction_filter.py failed: {e}")
+

--- a/ush/python/pyobsforge/task/atmos_bufr_prepobs.py
+++ b/ush/python/pyobsforge/task/atmos_bufr_prepobs.py
@@ -270,19 +270,15 @@ class AtmosBufrObsPrep(Task):
         # Run unified restriction filter AFTER finalize
         stats_yaml = os.path.join(self.task_config.DATA, "stats.yaml")
 
-        script_path = os.path.join(
-            self.task_config.HOMEobsforge, "build", "bin", "ioda_restriction_filter.py"
-        )
-
         logger.info(f"Running unified restriction filter using {stats_yaml}")
 
-        exec_cmd = Executable("python")
-        exec_cmd.add_default_arg(script_path)
-        exec_cmd.add_default_arg("--stats")
-        exec_cmd.add_default_arg(stats_yaml)
+        # Add ioda-restrict directory to PYTHONPATH so we can import it
+        import sys
+        sys.path.append(os.path.join(self.task_config.HOMEobsforge, "build", "bin"))
+
+        from ioda_restriction_filter import main as restriction_main
 
         try:
-            exec_cmd()
+            restriction_main(stats_yaml)
         except Exception as e:
             logger.warning(f"ioda_restriction_filter.py failed: {e}")
-

--- a/ush/python/pyobsforge/task/atmos_bufr_prepobs.py
+++ b/ush/python/pyobsforge/task/atmos_bufr_prepobs.py
@@ -257,7 +257,7 @@ class AtmosBufrObsPrep(Task):
             'output file': str(ready_file),
         }
         save_as_yaml(summary_dict, os.path.join(self.task_config.DATA, "stats.yaml"))
-        exec_cmd = Executable(os.path.join(self.task_config.HOMEobsforge, "build", "bin", "ioda-dump.x"))
+        exec_cmd = Executable(os.path.join(self.task_config.HOMEobsforge, "build", "bin", "ioda-summary.x"))
         exec_cmd.add_default_arg(os.path.join(self.task_config.DATA, "stats.yaml"))
         try:
             logger.info(f"Creating summary file {ready_file}")
@@ -274,11 +274,12 @@ class AtmosBufrObsPrep(Task):
 
         # Add ioda-restrict directory to PYTHONPATH so we can import it
         import sys
+
         sys.path.append(os.path.join(self.task_config.HOMEobsforge, "build", "bin"))
 
-        from ioda_restriction_filter import main as restriction_main
+        from ioda_restriction_filter import run_rsrd_exprsrd as restriction_filter
 
         try:
-            restriction_main(stats_yaml)
+            restriction_filter(stats_yaml)
         except Exception as e:
             logger.warning(f"ioda_restriction_filter.py failed: {e}")


### PR DESCRIPTION
This PR updates atmos_bufr_prepobs.py to integrate the new restriction‑screening workflow. The script reads restrictionFlag and restrictionExpiration from the MetaData group and determines which observations should be retained or dropped before writing the output IODA netCDF file.