### PR TITLE
Fix duplicated observations from processing marine obs

### DIFF
--- a/utils/preproc/NetCDFToIodaConverter.h
+++ b/utils/preproc/NetCDFToIodaConverter.h
@@ -91,7 +91,7 @@ namespace obsforge {
       gatherObs(iodaVars.obsError_, iodaVarsAll.obsError_);
       gatherObs(iodaVars.preQc_, iodaVarsAll.preQc_);
 
-      // gather floatMetadata_ (depth) — Matrix → Array 변환
+      // Gather floatMetadata_ (depth)
       for (int col = 0; col < iodaVars.floatMetadata_.cols(); col++) {
         Eigen::Array<float, Eigen::Dynamic, 1> srcCol =
             iodaVars.floatMetadata_.col(col).array();
@@ -100,7 +100,7 @@ namespace obsforge {
         iodaVarsAll.floatMetadata_.col(col) = dstCol.matrix();
       }
 
-      // gather intMetadata_ (oceanbasin, rcptdateTime, stationID)
+      // Gather intMetadata_ (oceanbasin, rcptdateTime, stationID)
       for (int col = 0; col < iodaVars.intMetadata_.cols(); col++) {
         Eigen::Array<int, Eigen::Dynamic, 1> srcCol =
             iodaVars.intMetadata_.col(col).array();
@@ -109,9 +109,9 @@ namespace obsforge {
         iodaVarsAll.intMetadata_.col(col) = dstCol.matrix();
       }
 
-      // ── removeDuplicates on root PE only ─────────────────────────────────
+      // RemoveDuplicates on root PE only
       if (oops::mpi::world().rank() == 0) {
-        iodaVarsAll.removeDuplicates();   // void — int 로 받지 않음
+        iodaVarsAll.removeDuplicates();
       }
 
       // Create empty group backed by HDF file

--- a/utils/preproc/NetCDFToIodaConverter.h
+++ b/utils/preproc/NetCDFToIodaConverter.h
@@ -91,6 +91,28 @@ namespace obsforge {
       gatherObs(iodaVars.obsError_, iodaVarsAll.obsError_);
       gatherObs(iodaVars.preQc_, iodaVarsAll.preQc_);
 
+      // gather floatMetadata_ (depth) — Matrix → Array 변환
+      for (int col = 0; col < iodaVars.floatMetadata_.cols(); col++) {
+        Eigen::Array<float, Eigen::Dynamic, 1> srcCol =
+            iodaVars.floatMetadata_.col(col).array();
+        Eigen::Array<float, Eigen::Dynamic, 1> dstCol(iodaVarsAll.location_);
+        gatherObs(srcCol, dstCol);
+        iodaVarsAll.floatMetadata_.col(col) = dstCol.matrix();
+      }
+
+      // gather intMetadata_ (oceanbasin, rcptdateTime, stationID)
+      for (int col = 0; col < iodaVars.intMetadata_.cols(); col++) {
+        Eigen::Array<int, Eigen::Dynamic, 1> srcCol =
+            iodaVars.intMetadata_.col(col).array();
+        Eigen::Array<int, Eigen::Dynamic, 1> dstCol(iodaVarsAll.location_);
+        gatherObs(srcCol, dstCol);
+        iodaVarsAll.intMetadata_.col(col) = dstCol.matrix();
+      }
+
+      // ── removeDuplicates on root PE only ─────────────────────────────────
+      if (oops::mpi::world().rank() == 0) {
+        iodaVarsAll.removeDuplicates();   // void — int 로 받지 않음
+      }
 
       // Create empty group backed by HDF file
       if (oops::mpi::world().rank() == 0) {

--- a/utils/preproc/util.h
+++ b/utils/preproc/util.h
@@ -271,6 +271,51 @@ namespace obsforge {
           }
           oops::Log::info() << "IodaVars::IodaVars done redating & adjsting errors." << std::endl;
         }
+
+        // Removing duplicated in-sutu obs
+        void removeDuplicates() {
+                  std::unordered_map<std::string, int> seen;
+                  int nDups = 0;
+           
+          // true = keep, false = duplicate trim 
+          Eigen::Array<bool, Eigen::Dynamic, 1> keepMask(location_);
+          keepMask.setConstant(true);
+                
+          for (int i = 0; i < location_; i++) {
+          // Fingerprint key
+          std::ostringstream oss;
+          oss << std::fixed
+              << std::setprecision(6) << latitude_(i)         << "|"
+              << std::setprecision(6) << longitude_(i)        << "|"
+              << std::setprecision(2) << floatMetadata_(i, 0) << "|"  // depth (col 0)
+              <<                         datetime_(i)         << "|"  // int64_t
+              << std::setprecision(6) << obsVal_(i);               // salinity or waterTemp
+
+          std::string key = oss.str();
+
+          if (seen.find(key) == seen.end()) {
+            seen[key] = i;
+            } else {
+              keepMask(i) = false;   // mark as duplicate
+              nDups++;
+              oops::Log::debug() << "removeDuplicates: duplicate at index " << i
+                                 << " (first seen at index " << seen[key] << ")"
+                                 << std::endl;
+            }
+          }
+
+          if (nDups == 0) {
+            oops::Log::info() << "IodaVars::removeDuplicates: no duplicates found."
+                              << std::endl;
+          return;
+          }
+
+          trim(keepMask);
+
+          oops::Log::info() << "IodaVars::removeDuplicates: removed " << nDups
+                            << " duplicates, " << location_ << " obs remaining."
+                            << std::endl;
+          }
       };
     }  // namespace iodavars
 

--- a/utils/preproc/util.h
+++ b/utils/preproc/util.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <unordered_map>
+#include <sstream>
+#include <iomanip>
 #include <iostream>
 #include <limits>
 #include <map>
@@ -272,42 +275,46 @@ namespace obsforge {
           oops::Log::info() << "IodaVars::IodaVars done redating & adjsting errors." << std::endl;
         }
 
-        // Removing duplicated in-sutu obs
+        // Removing duplicated in-situ obs
         void removeDuplicates() {
-                  std::unordered_map<std::string, int> seen;
-                  int nDups = 0;
-           
-          // true = keep, false = duplicate trim 
+               std::unordered_map<std::string, int> seen;
+               int nDups = 0;
+
           Eigen::Array<bool, Eigen::Dynamic, 1> keepMask(location_);
           keepMask.setConstant(true);
-                
+
+          bool hasDepth = (!floatMetadataName_.empty() && floatMetadata_.cols() > 0);
+
           for (int i = 0; i < location_; i++) {
-          // Fingerprint key
-          std::ostringstream oss;
-          oss << std::fixed
-              << std::setprecision(6) << latitude_(i)         << "|"
-              << std::setprecision(6) << longitude_(i)        << "|"
-              << std::setprecision(2) << floatMetadata_(i, 0) << "|"  // depth (col 0)
-              <<                         datetime_(i)         << "|"  // int64_t
-              << std::setprecision(6) << obsVal_(i);               // salinity or waterTemp
+            std::ostringstream oss;
+            oss << std::fixed
+                << std::setprecision(6) << latitude_(i)  << "|"
+                << std::setprecision(6) << longitude_(i) << "|";
 
-          std::string key = oss.str();
+            if (hasDepth) {
+              oss << std::setprecision(2) << floatMetadata_(i, 0) << "|";
+            }
 
-          if (seen.find(key) == seen.end()) {
-            seen[key] = i;
+            oss << datetime_(i)                          << "|"
+                << std::setprecision(6) << obsVal_(i);
+
+            std::string key = oss.str();
+
+            if (seen.find(key) == seen.end()) {
+              seen[key] = i;
             } else {
-              keepMask(i) = false;   // mark as duplicate
-              nDups++;
-              oops::Log::debug() << "removeDuplicates: duplicate at index " << i
-                                 << " (first seen at index " << seen[key] << ")"
-                                 << std::endl;
+            keepMask(i) = false;
+            nDups++;
+            oops::Log::debug() << "removeDuplicates: duplicate at index " << i
+                               << " (first seen at index " << seen[key] << ")"
+                               << std::endl;
             }
           }
 
           if (nDups == 0) {
             oops::Log::info() << "IodaVars::removeDuplicates: no duplicates found."
-                              << std::endl;
-          return;
+                      << std::endl;
+            return;
           }
 
           trim(keepMask);
@@ -315,7 +322,7 @@ namespace obsforge {
           oops::Log::info() << "IodaVars::removeDuplicates: removed " << nDups
                             << " duplicates, " << location_ << " obs remaining."
                             << std::endl;
-          }
+        }
       };
     }  // namespace iodavars
 


### PR DESCRIPTION
This PR includes removing duplicated observation from raw Argo (main reason) bufr file that has 50 minutes overlaps between each cycles (ex: 00z <-> 06z).

In order to remove duplications, a step for `compare/find/remove` should be in place right before generating netcdf file;

This is a draft; we need to test more by running real-time obsforge separately- it is now running-

