### PR TITLE
Remove Marine's Subdirectories

### DIFF
--- a/ush/python/pyobsforge/task/marine_bufr_prepobs.py
+++ b/ush/python/pyobsforge/task/marine_bufr_prepobs.py
@@ -41,7 +41,8 @@ class MarineBufrObsPrep(Task):
 
         local_dict = AttrDict(
             {
-                'COMIN_OBSPROC': f"{self.task_config.COMROOT}/{self.task_config.PSLOT}/{RUN}.{yyyymmdd}/{cycstr}/ocean/insitu",
+#                'COMIN_OBSPROC': f"{self.task_config.COMROOT}/{self.task_config.PSLOT}/{RUN}.{yyyymmdd}/{cycstr}/ocean/insitu",
+                'COMIN_OBSPROC': f"{self.task_config.COMROOT}/{self.task_config.PSLOT}/{RUN}.{yyyymmdd}/{cycstr}/ocean",
                 'window_begin': to_isotime(_window_begin),
                 'window_end': to_isotime(_window_end),
                 'OCNOBS2IODAEXEC': OCNOBS2IODAEXEC,
@@ -242,3 +243,34 @@ class MarineBufrObsPrep(Task):
         ready_file = pathlib.Path(path.join(self.task_config.COMIN_OBSPROC,
                                             f"{self.task_config['PREFIX']}obsforge_marine_bufr_status.log"))
         ready_file.touch()
+
+# block below is for symlinks [Hyundeok Choi]
+        # -------------------------------------------------------------
+        # Create legacy ocean subdirectory symlinks for backward compatibility
+        # -------------------------------------------------------------
+        import shutil
+
+        # COMIN_OBSPROC now points to the merged ocean directory
+        comout = self.task_config.COMIN_OBSPROC
+
+        # Legacy subdirectories to recreate as symlinks
+        legacy_dirs = ["insitu", "sst", "sss", "adt", "icec"]
+
+        for d in legacy_dirs:
+            link_path = pathlib.Path(path.join(comout, d))
+            target = pathlib.Path(comout)
+
+            # Remove existing directory or symlink
+            if link_path.exists() or link_path.is_symlink():
+                try:
+                    link_path.unlink()
+                except IsADirectoryError:
+                    shutil.rmtree(link_path)
+
+            # Create symlink
+            try:
+                link_path.symlink_to(target)
+                logger.info(f"Created symlink: {link_path} -> {target}")
+            except Exception as e:
+                logger.warning(f"Failed to create symlink {link_path}: {e}")
+

--- a/ush/python/pyobsforge/task/marine_bufr_prepobs.py
+++ b/ush/python/pyobsforge/task/marine_bufr_prepobs.py
@@ -41,7 +41,6 @@ class MarineBufrObsPrep(Task):
 
         local_dict = AttrDict(
             {
-#                'COMIN_OBSPROC': f"{self.task_config.COMROOT}/{self.task_config.PSLOT}/{RUN}.{yyyymmdd}/{cycstr}/ocean/insitu",
                 'COMIN_OBSPROC': f"{self.task_config.COMROOT}/{self.task_config.PSLOT}/{RUN}.{yyyymmdd}/{cycstr}/ocean",
                 'window_begin': to_isotime(_window_begin),
                 'window_end': to_isotime(_window_end),
@@ -244,7 +243,6 @@ class MarineBufrObsPrep(Task):
                                             f"{self.task_config['PREFIX']}obsforge_marine_bufr_status.log"))
         ready_file.touch()
 
-# block below is for symlinks [Hyundeok Choi]
         # -------------------------------------------------------------
         # Create legacy ocean subdirectory symlinks for backward compatibility
         # -------------------------------------------------------------

--- a/ush/python/pyobsforge/task/marine_bufr_prepobs.py
+++ b/ush/python/pyobsforge/task/marine_bufr_prepobs.py
@@ -5,7 +5,7 @@ from os import path
 import pathlib
 from typing import Dict, Any
 from wxflow import (
-    AttrDict
+    AttrDict,
     Executable,
     FileHandler,
     Task,

--- a/ush/python/pyobsforge/task/marine_bufr_prepobs.py
+++ b/ush/python/pyobsforge/task/marine_bufr_prepobs.py
@@ -19,6 +19,8 @@ from wxflow import (
 )
 from pyobsforge.task.sfcshp import SfcShp
 import netCDF4
+import shutil   
+import pathlib  
 
 logger = getLogger(__name__.split('.')[-1])
 
@@ -116,10 +118,8 @@ class MarineBufrObsPrep(Task):
                     else:
                         logger.warning(f"sfcshp not found: {sfcshp_filename}")
 
-                # if the bufr file exists in OBSPROC_COMROOT, set it up for copy
-                # and conversion
-                # if the bufr file exists in RUNDIR (because it was split from
-                # sfcshp in OBSPROC_COMROOT), set it up for conversion
+                # if the bufr file exists in OBSPROC_COMROOT, set it up for copy and conversion
+                # if the bufr file exists in RUNDIR (because it was split from sfcshp in OBSPROC_COMROOT), set it up for conversion
                 logger.debug(f"Looking for {obs_cycle_config.dump_filename}...")
                 if path.exists(obs_cycle_config.dump_filename):
                     save_as_yaml(obs_cycle_config, obs_cycle_config.bufr2ioda_yaml)
@@ -192,8 +192,7 @@ class MarineBufrObsPrep(Task):
                     logger.debug("Exception details", exc_info=True)
                     continue  # skip to the next obs_cycle_config
 
-            # for each variable in the converted ioda file, concat all of the
-            # converted ioda files in the window
+            # for each variable in the converted ioda file, concat all of the converted ioda files in the window
             for concat_config in provider['concat_configs']:
                 final_input_files = []
                 for input_file in concat_config['input files']:
@@ -246,7 +245,6 @@ class MarineBufrObsPrep(Task):
         # -------------------------------------------------------------
         # Create legacy ocean subdirectory symlinks for backward compatibility
         # -------------------------------------------------------------
-        import shutil
 
         # COMIN_OBSPROC now points to the merged ocean directory
         comout = self.task_config.COMIN_OBSPROC

--- a/ush/python/pyobsforge/task/marine_bufr_prepobs.py
+++ b/ush/python/pyobsforge/task/marine_bufr_prepobs.py
@@ -229,7 +229,10 @@ class MarineBufrObsPrep(Task):
                 logger.info(f"ioda_filename: {ioda_filename}")
                 source_ioda_filename = path.join(self.task_config.DATA, ioda_filename)
                 if path.exists(source_ioda_filename):
-                    destination_ioda_filename = path.join(self.task_config.COMIN_OBSPROC, concat_config['save file'])
+                    destination_ioda_filename = path.join(
+                        self.task_config.COMIN_OBSPROC,
+                        concat_config['save file']
+                    )
                     # Only append if source_ioda_filename is a valid NetCDF4 file
                     try:
                         with netCDF4.Dataset(source_ioda_filename, 'r'):
@@ -237,38 +240,48 @@ class MarineBufrObsPrep(Task):
                     except Exception:
                         logger.warning(f"Skipping invalid file: {source_ioda_filename}")
 
+        # -------------------------------------------------------------
+        # FIX: Ensure COMIN_OBSPROC exists BEFORE copying
+        # -------------------------------------------------------------
+        FileHandler({'mkdir': [self.task_config.COMIN_OBSPROC]}).sync()
+
+        # Now perform the copy
         FileHandler({'copy_opt': ioda_files_to_copy}).sync()
 
         # create an empty file to tell external processes the obs are ready
-        ready_file = pathlib.Path(path.join(self.task_config.COMIN_OBSPROC,
-                                            f"{self.task_config['PREFIX']}obsforge_marine_bufr_status.log"))
-        pathlib.Path(self.task_config.COMIN_OBSPROC).mkdir(parents=True, exist_ok=True)
+        ready_file = pathlib.Path(path.join(
+            self.task_config.COMIN_OBSPROC,
+            f"{self.task_config['PREFIX']}obsforge_marine_bufr_status.log"
+        ))
         ready_file.touch()
 
         # -------------------------------------------------------------
-        # Create legacy ocean subdirectory symlinks for backward compatibility
+        # Create legacy ocean subdirectory structure without cycles
         # -------------------------------------------------------------
-
-        # COMIN_OBSPROC now points to the merged ocean directory
-        comout = self.task_config.COMIN_OBSPROC
-
-        # Legacy subdirectories to recreate as symlinks
+        comout = pathlib.Path(self.task_config.COMIN_OBSPROC)
         legacy_dirs = ["insitu", "sst", "sss", "adt", "icec"]
 
+        # Gather all .nc files in the merged ocean directory
+        all_nc_files = list(comout.glob("*.nc"))
+
         for d in legacy_dirs:
-            link_path = pathlib.Path(path.join(comout, d))
-            target = pathlib.Path(comout)
+            legacy_dir = comout / d
 
             # Remove existing directory or symlink
-            if link_path.exists() or link_path.is_symlink():
+            if legacy_dir.exists() or legacy_dir.is_symlink():
                 try:
-                    link_path.unlink()
+                    legacy_dir.unlink()
                 except IsADirectoryError:
-                    shutil.rmtree(link_path)
+                    shutil.rmtree(legacy_dir)
 
-            # Create symlink
-            try:
-                link_path.symlink_to(target)
-                logger.info(f"Created symlink: {link_path} -> {target}")
-            except Exception as e:
-                logger.warning(f"Failed to create symlink {link_path}: {e}")
+            # Create a real directory
+            legacy_dir.mkdir(parents=True, exist_ok=True)
+ 
+            # Create per-file symlinks inside it
+            for nc_file in all_nc_files:
+                link_path = legacy_dir / nc_file.name
+                try:
+                    link_path.symlink_to(nc_file)
+                    logger.info(f"Created file symlink: {link_path} -> {nc_file}")
+                except Exception as e:
+                    logger.warning(f"Failed to create file symlink {link_path}: {e}")

--- a/ush/python/pyobsforge/task/marine_bufr_prepobs.py
+++ b/ush/python/pyobsforge/task/marine_bufr_prepobs.py
@@ -268,4 +268,3 @@ class MarineBufrObsPrep(Task):
                 logger.info(f"Created symlink: {link_path} -> {target}")
             except Exception as e:
                 logger.warning(f"Failed to create symlink {link_path}: {e}")
-

--- a/ush/python/pyobsforge/task/marine_bufr_prepobs.py
+++ b/ush/python/pyobsforge/task/marine_bufr_prepobs.py
@@ -117,8 +117,10 @@ class MarineBufrObsPrep(Task):
                     else:
                         logger.warning(f"sfcshp not found: {sfcshp_filename}")
 
-                # if the bufr file exists in OBSPROC_COMROOT, set it up for copy and conversion
-                # if the bufr file exists in RUNDIR (because it was split from sfcshp in OBSPROC_COMROOT), set it up for conversion
+                # if the bufr file exists in OBSPROC_COMROOT, set it up for copy
+                # and conversion
+                # if the bufr file exists in RUNDIR (because it was split from
+                # sfcshp in OBSPROC_COMROOT), set it up for conversion
                 logger.debug(f"Looking for {obs_cycle_config.dump_filename}...")
                 if path.exists(obs_cycle_config.dump_filename):
                     save_as_yaml(obs_cycle_config, obs_cycle_config.bufr2ioda_yaml)
@@ -191,7 +193,8 @@ class MarineBufrObsPrep(Task):
                     logger.debug("Exception details", exc_info=True)
                     continue  # skip to the next obs_cycle_config
 
-            # for each variable in the converted ioda file, concat all of the converted ioda files in the window
+            # for each variable in the converted ioda file, concat all of the
+            # converted ioda files in the window
             for concat_config in provider['concat_configs']:
                 final_input_files = []
                 for input_file in concat_config['input files']:

--- a/ush/python/pyobsforge/task/marine_bufr_prepobs.py
+++ b/ush/python/pyobsforge/task/marine_bufr_prepobs.py
@@ -242,6 +242,7 @@ class MarineBufrObsPrep(Task):
         # create an empty file to tell external processes the obs are ready
         ready_file = pathlib.Path(path.join(self.task_config.COMIN_OBSPROC,
                                             f"{self.task_config['PREFIX']}obsforge_marine_bufr_status.log"))
+        pathlib.Path(self.task_config.COMIN_OBSPROC).mkdir(parents=True, exist_ok=True)
         ready_file.touch()
 
         # -------------------------------------------------------------

--- a/ush/python/pyobsforge/task/marine_bufr_prepobs.py
+++ b/ush/python/pyobsforge/task/marine_bufr_prepobs.py
@@ -2,8 +2,9 @@
 
 from logging import getLogger
 from os import path
+import pathlib
 from typing import Dict, Any
-from wxflow import 
+from wxflow import (
     AttrDict
     Executable,
     FileHandler,
@@ -19,7 +20,6 @@ from wxflow import
 from pyobsforge.task.sfcshp import SfcShp
 import netCDF4
 import shutil
-import pathlib
 
 logger = getLogger(__name__.split('.')[-1])
 

--- a/ush/python/pyobsforge/task/marine_bufr_prepobs.py
+++ b/ush/python/pyobsforge/task/marine_bufr_prepobs.py
@@ -261,9 +261,6 @@ class MarineBufrObsPrep(Task):
         comout = pathlib.Path(self.task_config.COMIN_OBSPROC)
         legacy_dirs = ["insitu", "sst", "sss", "adt", "icec"]
 
-        # Gather all .nc files in the merged ocean directory
-        all_nc_files = list(comout.glob("*.nc"))
-
         for d in legacy_dirs:
             legacy_dir = comout / d
 
@@ -276,8 +273,13 @@ class MarineBufrObsPrep(Task):
 
             # Create a real directory
             legacy_dir.mkdir(parents=True, exist_ok=True)
-            # Create per-file symlinks inside it
-            for nc_file in all_nc_files:
+
+            # Filter files by obs-type (e.g., *sst_*.nc)
+            pattern = f"*{d}_*.nc"
+            matching_files = comout.glob(pattern)
+
+            # Create per-file symlinks
+            for nc_file in matching_files:
                 link_path = legacy_dir / nc_file.name
                 try:
                     link_path.symlink_to(nc_file)

--- a/ush/python/pyobsforge/task/marine_bufr_prepobs.py
+++ b/ush/python/pyobsforge/task/marine_bufr_prepobs.py
@@ -2,10 +2,9 @@
 
 from logging import getLogger
 from os import path
-import pathlib
 from typing import Dict, Any
-from wxflow import (
-    AttrDict,
+from wxflow import 
+    AttrDict
     Executable,
     FileHandler,
     Task,
@@ -19,8 +18,8 @@ from wxflow import (
 )
 from pyobsforge.task.sfcshp import SfcShp
 import netCDF4
-import shutil   
-import pathlib  
+import shutil
+import pathlib
 
 logger = getLogger(__name__.split('.')[-1])
 

--- a/ush/python/pyobsforge/task/marine_bufr_prepobs.py
+++ b/ush/python/pyobsforge/task/marine_bufr_prepobs.py
@@ -276,7 +276,6 @@ class MarineBufrObsPrep(Task):
 
             # Create a real directory
             legacy_dir.mkdir(parents=True, exist_ok=True)
- 
             # Create per-file symlinks inside it
             for nc_file in all_nc_files:
                 link_path = legacy_dir / nc_file.name

--- a/ush/python/pyobsforge/task/marine_prepobs.py
+++ b/ush/python/pyobsforge/task/marine_prepobs.py
@@ -263,7 +263,7 @@ class MarineObsPrep(Task):
         src_dst_obs_list = []  # list of [src_file, dst_file]
         for obs_type in obs_types:
             # Create the destination directory
-            comout_tmp = comout   # everything goes into ocean/
+#            comout_tmp = comout   # everything goes into ocean/
 
             # Glob the ioda files
             ioda_files = glob.glob(join(self.task_config['DATA'],

--- a/ush/python/pyobsforge/task/marine_prepobs.py
+++ b/ush/python/pyobsforge/task/marine_prepobs.py
@@ -263,10 +263,6 @@ class MarineObsPrep(Task):
         src_dst_obs_list = []  # list of [src_file, dst_file]
         for obs_type in obs_types:
             # Create the destination directory
-#            comout_tmp = join(comout, obs_type)
-#            FileHandler({'mkdir': [comout_tmp]}).sync()
-
-            # Hyundeok.Choi
             comout_tmp = comout   # everything goes into ocean/
 
             # Glob the ioda files
@@ -275,8 +271,6 @@ class MarineObsPrep(Task):
             for ioda_file in ioda_files:
                 logger.info(f"ioda_file: {ioda_file}")
                 src_file = ioda_file
-#                dst_file = join(comout_tmp, basename(ioda_file))
-                # Hyundeok.Choi
                 dst_file = join(comout, basename(ioda_file))
 
                 src_dst_obs_list.append([src_file, dst_file])
@@ -289,8 +283,6 @@ class MarineObsPrep(Task):
         # create an empty file to tell external processes the obs are ready
         ready_file = pathlib.Path(join(comout, f"{self.task_config['PREFIX']}obsforge_marine_status.log"))
         ready_file.touch()
-
-        # Hyundeok.Choi
 
         # Create legacy subdirectory symlinks for backward compatibility
         legacy_dirs = ["sst", "adt", "icec", "sss", "insitu"]

--- a/ush/python/pyobsforge/task/marine_prepobs.py
+++ b/ush/python/pyobsforge/task/marine_prepobs.py
@@ -263,8 +263,11 @@ class MarineObsPrep(Task):
         src_dst_obs_list = []  # list of [src_file, dst_file]
         for obs_type in obs_types:
             # Create the destination directory
-            comout_tmp = join(comout, obs_type)
-            FileHandler({'mkdir': [comout_tmp]}).sync()
+#            comout_tmp = join(comout, obs_type)
+#            FileHandler({'mkdir': [comout_tmp]}).sync()
+
+            # Hyundeok.Choi
+            comout_tmp = comout   # everything goes into ocean/
 
             # Glob the ioda files
             ioda_files = glob.glob(join(self.task_config['DATA'],
@@ -272,7 +275,10 @@ class MarineObsPrep(Task):
             for ioda_file in ioda_files:
                 logger.info(f"ioda_file: {ioda_file}")
                 src_file = ioda_file
-                dst_file = join(comout_tmp, basename(ioda_file))
+#                dst_file = join(comout_tmp, basename(ioda_file))
+                # Hyundeok.Choi
+                dst_file = join(comout, basename(ioda_file))
+
                 src_dst_obs_list.append([src_file, dst_file])
 
         logger.info("Copying ioda files to destination COMROOT directory")
@@ -283,3 +289,27 @@ class MarineObsPrep(Task):
         # create an empty file to tell external processes the obs are ready
         ready_file = pathlib.Path(join(comout, f"{self.task_config['PREFIX']}obsforge_marine_status.log"))
         ready_file.touch()
+
+        # Hyundeok.Choi
+
+        # Create legacy subdirectory symlinks for backward compatibility
+        legacy_dirs = ["sst", "adt", "icec", "sss", "insitu"]
+
+        for d in legacy_dirs:
+            link_path = join(comout, d)
+            target = comout  # all symlinks point to the merged ocean directory
+
+            # Remove existing directory or symlink if present
+            if pathlib.Path(link_path).exists() or pathlib.Path(link_path).is_symlink():
+                try:
+                    pathlib.Path(link_path).unlink()
+                except IsADirectoryError:
+                    shutil.rmtree(link_path)
+
+            # Create symlink
+            try:
+                pathlib.Path(link_path).symlink_to(target)
+                logger.info(f"Created symlink: {link_path} -> {target}")
+            except Exception as e:
+                logger.warning(f"Failed to create symlink {link_path}: {e}")
+

--- a/ush/python/pyobsforge/task/marine_prepobs.py
+++ b/ush/python/pyobsforge/task/marine_prepobs.py
@@ -248,8 +248,12 @@ class MarineObsPrep(Task):
     @logit(logger)
     def finalize(self) -> None:
         """
+        Finalize marine obsForge processing:
+          - Ensure COMOUT exists
+          - Copy IODA files
+          - Create ready-file flag
+          - Create legacy directories with per-file symlinks (no directory cycles)
         """
-        # Copy the processed ioda files to the destination directory
         logger.info("Copying ioda files to destination COMROOT directory")
         yyyymmdd = self.task_config['PDY'].strftime('%Y%m%d')
 
@@ -259,49 +263,67 @@ class MarineObsPrep(Task):
                       f"{self.task_config['cyc']:02d}",
                       'ocean')
 
-        # Loop through the observation types
-        obs_types = ['sst', 'adt', 'icec', 'sss']
-        src_dst_obs_list = []  # list of [src_file, dst_file]
-        for obs_type in obs_types:
-            # Create the destination directory
+        # ----------------------------------------------------------------------
+        # Ensure comout exists BEFORE any copy operations
+        # ----------------------------------------------------------------------
+        FileHandler({'mkdir': [comout]}).sync()
 
-            # Glob the ioda files
+        # ----------------------------------------------------------------------
+        # Build list of IODA files to copy
+        # ----------------------------------------------------------------------
+        obs_types = ['sst', 'adt', 'icec', 'sss']
+        src_dst_obs_list = []
+
+        for obs_type in obs_types:
             ioda_files = glob.glob(join(self.task_config['DATA'],
-                                        f"{self.task_config['PREFIX']}*{obs_type}_*.nc"))
+                                    f"{self.task_config['PREFIX']}*{obs_type}_*.nc"))
             for ioda_file in ioda_files:
                 logger.info(f"ioda_file: {ioda_file}")
                 src_file = ioda_file
                 dst_file = join(comout, basename(ioda_file))
-
                 src_dst_obs_list.append([src_file, dst_file])
 
-        logger.info("Copying ioda files to destination COMROOT directory")
         logger.info(f"src_dst_obs_list: {src_dst_obs_list}")
 
+        # Copy IODA files
         FileHandler({'copy': src_dst_obs_list}).sync()
 
-        # create an empty file to tell external processes the obs are ready
-        ready_file = pathlib.Path(join(comout, f"{self.task_config['PREFIX']}obsforge_marine_status.log"))
-        pathlib.Path(comout).mkdir(parents=True, exist_ok=True)
+        # ----------------------------------------------------------------------
+        # Create ready-file flag
+        # ----------------------------------------------------------------------
+        ready_file = pathlib.Path(join(
+            comout,
+            f"{self.task_config['PREFIX']}obsforge_marine_status.log"
+        ))
         ready_file.touch()
 
-        # Create legacy subdirectory symlinks for backward compatibility
+        # ----------------------------------------------------------------------
+        # Create legacy subdirectories WITHOUT directory cycles
+        # ----------------------------------------------------------------------
         legacy_dirs = ["sst", "adt", "icec", "sss", "insitu"]
+        comout_path = pathlib.Path(comout)
+
+        # Gather all .nc files in the merged ocean directory
+        all_nc_files = list(comout_path.glob("*.nc"))
 
         for d in legacy_dirs:
-            link_path = join(comout, d)
-            target = comout  # all symlinks point to the merged ocean directory
+            legacy_dir = comout_path / d
 
-            # Remove existing directory or symlink if present
-            if pathlib.Path(link_path).exists() or pathlib.Path(link_path).is_symlink():
+            # Remove existing directory or symlink
+            if legacy_dir.exists() or legacy_dir.is_symlink():
                 try:
-                    pathlib.Path(link_path).unlink()
+                    legacy_dir.unlink()
                 except IsADirectoryError:
-                    shutil.rmtree(link_path)
+                    shutil.rmtree(legacy_dir)
 
-            # Create symlink
-            try:
-                pathlib.Path(link_path).symlink_to(target)
-                logger.info(f"Created symlink: {link_path} -> {target}")
-            except Exception as e:
-                logger.warning(f"Failed to create symlink {link_path}: {e}")
+            # Create a real directory
+            legacy_dir.mkdir(parents=True, exist_ok=True)
+
+            # Create per-file symlinks inside it
+            for nc_file in all_nc_files:
+                link_path = legacy_dir / nc_file.name
+                try:
+                    link_path.symlink_to(nc_file)
+                    logger.info(f"Created file symlink: {link_path} -> {nc_file}")
+                except Exception as e:
+                    logger.warning(f"Failed to create file symlink {link_path}: {e}")

--- a/ush/python/pyobsforge/task/marine_prepobs.py
+++ b/ush/python/pyobsforge/task/marine_prepobs.py
@@ -264,7 +264,6 @@ class MarineObsPrep(Task):
         src_dst_obs_list = []  # list of [src_file, dst_file]
         for obs_type in obs_types:
             # Create the destination directory
-#            comout_tmp = comout   # everything goes into ocean/
 
             # Glob the ioda files
             ioda_files = glob.glob(join(self.task_config['DATA'],
@@ -305,4 +304,3 @@ class MarineObsPrep(Task):
                 logger.info(f"Created symlink: {link_path} -> {target}")
             except Exception as e:
                 logger.warning(f"Failed to create symlink {link_path}: {e}")
-

--- a/ush/python/pyobsforge/task/marine_prepobs.py
+++ b/ush/python/pyobsforge/task/marine_prepobs.py
@@ -276,8 +276,10 @@ class MarineObsPrep(Task):
 
         for obs_type in obs_types:
             ioda_files = glob.glob(
-                    join(self.task_config['DATA'],
-                         f"{self.task_config['PREFIX']}*{obs_type}_*.nc")
+                join(
+                    self.task_config['DATA'],
+                    f"{self.task_config['PREFIX']}*{obs_type}_*.nc"
+                )
             )
             for ioda_file in ioda_files:
                 logger.info(f"ioda_file: {ioda_file}")

--- a/ush/python/pyobsforge/task/marine_prepobs.py
+++ b/ush/python/pyobsforge/task/marine_prepobs.py
@@ -275,8 +275,10 @@ class MarineObsPrep(Task):
         src_dst_obs_list = []
 
         for obs_type in obs_types:
-            ioda_files = glob.glob(join(self.task_config['DATA'],
-                                    f"{self.task_config['PREFIX']}*{obs_type}_*.nc"))
+            ioda_files = glob.glob(
+                    join(self.task_config['DATA'],
+                         f"{self.task_config['PREFIX']}*{obs_type}_*.nc")
+            )
             for ioda_file in ioda_files:
                 logger.info(f"ioda_file: {ioda_file}")
                 src_file = ioda_file

--- a/ush/python/pyobsforge/task/marine_prepobs.py
+++ b/ush/python/pyobsforge/task/marine_prepobs.py
@@ -10,6 +10,7 @@ from datetime import timedelta
 import glob
 from os.path import basename
 import pathlib
+import shutil
 
 logger = getLogger(__name__.split('.')[-1])
 

--- a/ush/python/pyobsforge/task/marine_prepobs.py
+++ b/ush/python/pyobsforge/task/marine_prepobs.py
@@ -307,9 +307,6 @@ class MarineObsPrep(Task):
         legacy_dirs = ["sst", "adt", "icec", "sss", "insitu"]
         comout_path = pathlib.Path(comout)
 
-        # Gather all .nc files in the merged ocean directory
-        all_nc_files = list(comout_path.glob("*.nc"))
-
         for d in legacy_dirs:
             legacy_dir = comout_path / d
 
@@ -320,11 +317,14 @@ class MarineObsPrep(Task):
                 except IsADirectoryError:
                     shutil.rmtree(legacy_dir)
 
-            # Create a real directory
+            # Create real directory
             legacy_dir.mkdir(parents=True, exist_ok=True)
 
-            # Create per-file symlinks inside it
-            for nc_file in all_nc_files:
+            # Filter files by obs-type
+            pattern = f"*{d}_*.nc"
+            matching_files = comout_path.glob(pattern)
+
+            for nc_file in matching_files:
                 link_path = legacy_dir / nc_file.name
                 try:
                     link_path.symlink_to(nc_file)

--- a/ush/python/pyobsforge/task/marine_prepobs.py
+++ b/ush/python/pyobsforge/task/marine_prepobs.py
@@ -282,6 +282,7 @@ class MarineObsPrep(Task):
 
         # create an empty file to tell external processes the obs are ready
         ready_file = pathlib.Path(join(comout, f"{self.task_config['PREFIX']}obsforge_marine_status.log"))
+        pathlib.Path(comout).mkdir(parents=True, exist_ok=True)
         ready_file.touch()
 
         # Create legacy subdirectory symlinks for backward compatibility


### PR DESCRIPTION
This PR implements the directory‑structure changes requested in Issue #209 by removing the legacy marine subdirectories under com/obsforge and transitioning to a unified, flat marine directory layout. 
1. Removed the per‑type marine subdirectories (sst/, sss/, adt/, icec/, insitu/.) from the ObsForge COM directory structure, so that all marine NetCDF files are written directly into a single unified directory.
2. Added backward‑compatibility symlinks that recreate the old subdirectory layout, pointing into the new unified directory.
This allows real‑time operations to continue uninterrupted.
3. Ensured that both the old and new structures coexist safely during the transition period.