### PR TITLE
Handling empty input files, excess MPI tasks, and temp dtype casting

### DIFF
--- a/utils/b2i/b2iconverter/ioda_variables.py
+++ b/utils/b2i/b2iconverter/ioda_variables.py
@@ -4,10 +4,6 @@ from .util import *
 from .ioda_metadata import IODAMetadata
 from .ioda_addl_vars import IODAAdditionalVariables
 
-# Error values are hard-coded in the converters using functions
-# like the set_salinity_error below
-# These values are overwritten at run time.
-
 
 class IODAVariables:
     def __init__(self):
@@ -119,7 +115,7 @@ class IODAVariables:
 ##########################################################################
 
     def set_obs_from_query_result(self, r):
-        self.temp = r.get('temp', group_by='depth')
+        self.temp = r.get('temp', group_by='depth').astype(np.float32)
         self.temp -= 273.15
         self.saln = r.get('saln', group_by='depth')
 

--- a/utils/b2i/bathy_ioda_variables.py
+++ b/utils/b2i/bathy_ioda_variables.py
@@ -19,7 +19,7 @@ class BathyIODAVariables(IODAVariables):
         return q
 
     def set_obs_from_query_result(self, r):
-        self.temp = r.get('temp', group_by='depth')
+        self.temp = r.get('temp', group_by='depth').astype(np.float32)
         self.temp -= 273.15
 
     def filter(self):

--- a/utils/b2i/bufr2ioda_insitu_surface_ndbc.py
+++ b/utils/b2i/bufr2ioda_insitu_surface_ndbc.py
@@ -37,7 +37,7 @@ class NDBCIODAVariables(IODAVariables):
         return q
     
     def set_obs_from_query_result(self, r):
-        self.temp = r.get('temp')
+        self.temp = r.get('temp').astype(np.float32)
         self.temp -= 273.15
 
     def filter(self):

--- a/utils/b2i/dbuoyb_surface_ioda_variables.py
+++ b/utils/b2i/dbuoyb_surface_ioda_variables.py
@@ -32,7 +32,7 @@ class DbuoybIODAVariables(IODAVariables):
         return q
 
     def set_obs_from_query_result(self, r):
-        self.temp = r.get('temp')
+        self.temp = r.get('temp').astype(np.float32)
         self.temp -= 273.15
 
     def filter(self):

--- a/utils/b2i/drifter_ioda_variables.py
+++ b/utils/b2i/drifter_ioda_variables.py
@@ -34,7 +34,7 @@ class DrifterIODAVariables(IODAVariables):
         return q
 
     def set_obs_from_query_result(self, r):
-        self.temp = r.get('temp', group_by='depth')
+        self.temp = r.get('temp', group_by='depth').astype(np.float32)
         self.temp -= 273.15
 
     def filter(self):

--- a/utils/preproc/NetCDFToIodaConverter.h
+++ b/utils/preproc/NetCDFToIodaConverter.h
@@ -60,7 +60,7 @@ namespace obsforge {
       int nchan(0);
 
       // Handle empty input file list gracefully
-      // Some obs types (e.g. BATHY, RAMA) may have zero input files when concatinating
+      // Some obs types (e.g. BATHY, RAMA) may have zero input files when concatenating
       if (inputFilenames_.empty()) {
        oops::Log::warning() << "writeToIoda: No input files found for "
                              << outputFilename_

--- a/utils/preproc/NetCDFToIodaConverter.h
+++ b/utils/preproc/NetCDFToIodaConverter.h
@@ -87,7 +87,7 @@ namespace obsforge {
                              << ") for " << outputFilename_
                              << " — excess PEs will be idle." << std::endl;
       }
-      
+
 
       // Read the provider's netcdf file
       obsforge::preproc::iodavars::IodaVars iodaVars;
@@ -100,14 +100,6 @@ namespace obsforge {
         oops::Log::info() << " obs count: " << iodaVars.location_ << std::endl;
         oops::Log::test() << "Reading: " << inputFilenames_ << std::endl;
         }
-      }
-      
-
-      for (int i = myrank + comm_.size(); i < inputFilenames_.size(); i += comm_.size()) {
-        iodaVars.append(providerToIodaVars(inputFilenames_[i]));
-        oops::Log::info() << " appending: " << inputFilenames_[i] << std::endl;
-        oops::Log::info() << " obs count: " << iodaVars.location_ << std::endl;
-        oops::Log::test() << "Reading: " << inputFilenames_ << std::endl;
       }
 
       nobs = iodaVars.location_;

--- a/utils/preproc/NetCDFToIodaConverter.h
+++ b/utils/preproc/NetCDFToIodaConverter.h
@@ -59,11 +59,49 @@ namespace obsforge {
       int nobs(0);
       int nchan(0);
 
-      // Currently need the PE count to be less than the number of files
-      ASSERT(comm_.size() <= inputFilenames_.size());
+      // Handle empty input file list gracefully
+      // Some obs types (e.g. BATHY, RAMA) may have zero input files when concatinating
+      if (inputFilenames_.empty()) {
+       oops::Log::warning() << "writeToIoda: No input files found for "
+                             << outputFilename_
+                             << " — creating empty output file." << std::endl;
+        if (oops::mpi::world().rank() == 0) {
+          ioda::Group group =
+            ioda::Engines::HH::createFile(outputFilename_,
+                                         ioda::Engines::BackendCreateModes::Truncate_If_Exists);
+         ioda::NewDimensionScales_t newDims {
+            ioda::NewDimensionScale<int>("Location", 0)
+          };
+         ioda::ObsGroup ogrp = ioda::ObsGroup::generate(group, newDims);
+         oops::Log::info() << "writeToIoda: empty output file created: "
+                            << outputFilename_ << std::endl;
+        }
+        return;
+      }
+
+      // Handle MPI PE count > input file count
+      // Each PE processes at least one file, excess PEs get no files
+      if (comm_.size() > inputFilenames_.size()) {
+        oops::Log::warning() << "writeToIoda: More MPI tasks (" << comm_.size()
+                             << ") than input files (" << inputFilenames_.size()
+                             << ") for " << outputFilename_
+                             << " — excess PEs will be idle." << std::endl;
+      }
+      
 
       // Read the provider's netcdf file
-      obsforge::preproc::iodavars::IodaVars iodaVars = providerToIodaVars(inputFilenames_[myrank]);
+      obsforge::preproc::iodavars::IodaVars iodaVars;
+
+      if (myrank < static_cast<int>(inputFilenames_.size())) {
+       iodaVars = providerToIodaVars(inputFilenames_[myrank]);
+       for (int i = myrank + comm_.size(); i < inputFilenames_.size(); i += comm_.size()) {
+        iodaVars.append(providerToIodaVars(inputFilenames_[i]));
+        oops::Log::info() << " appending: " << inputFilenames_[i] << std::endl;
+        oops::Log::info() << " obs count: " << iodaVars.location_ << std::endl;
+        oops::Log::test() << "Reading: " << inputFilenames_ << std::endl;
+        }
+      }
+      
 
       for (int i = myrank + comm_.size(); i < inputFilenames_.size(); i += comm_.size()) {
         iodaVars.append(providerToIodaVars(inputFilenames_[i]));
@@ -71,6 +109,7 @@ namespace obsforge {
         oops::Log::info() << " obs count: " << iodaVars.location_ << std::endl;
         oops::Log::test() << "Reading: " << inputFilenames_ << std::endl;
       }
+
       nobs = iodaVars.location_;
       nchan = iodaVars.channel_;
 


### PR DESCRIPTION
## Problem
Two separate bugs were causing warnings and crashes in the marine bufr preprocessing pipeline:

### 1. MPI ASSERT failure in writeToIoda
When input files are empty (e.g. BATHY, RAMA and more obs types with no data for a given cycle window), or when the number of MPI tasks exceeds the number of input files, the code crashes with:
```
  Assertion failed: comm_.size() <= inputFilenames_.size()
  in writeToIoda, NetCDFToIodaConverter.h
```

### 2. dtype casting error in Kelvin-to-Celsius conversion when BUFR query returns temperature data as int32, ubtracting `273.15 (float64)` raises:
```
  numpy.core._exceptions._UFuncOutputCastingError:
  Cannot cast ufunc 'subtract' output from dtype('float64')
  to dtype('int32') with casting rule 'same_kind'
```
This affects the following converters:
  - bathy_ioda_variables.py
  - dbuoyb_surface_ioda_variables.py
  - b2iconverter/ioda_variables.py (base class)
  - bufr2ioda_insitu_surface_ndbc.py
  - drifter_ioda_variables.py

## Changes
### NetCDFToIodaConverter.h
- Added early return with empty output file creation when `inputFilenames_` is empty
- Replaced hard ASSERT with a warning log when MPI task count exceeds input file count
- Excess PEs are now idle instead of crashing

### b2i/*.py
- Added .astype(np.float32) before -= 273.15 in all 5 affected files

## Testing w/ @HyundeokChoi-NOAA 
- Verified no backtrace/assertion errors for BATHY and RAMA more obs types with empty BUFR data
- Confirmed normal obs types (ARGO, etc.) are unaffected
- Verified temperature values are correctly converted from Kelvin to Celsius across all affected converters

## Close #227 