### PR TITLE
Fix of_setup.sh sourcing paths

### DIFF
--- a/dev/ush/of_setup.sh
+++ b/dev/ush/of_setup.sh
@@ -8,7 +8,7 @@
 # This script should be SOURCED to properly setup the environment.
 #
 
-HOMEobsforge="$(cd "$(dirname  "${BASH_SOURCE[0]}")/.." >/dev/null 2>&1 && pwd )"
+HOMEobsforge="$(cd "$(dirname  "${BASH_SOURCE[0]}")/../.." >/dev/null 2>&1 && pwd )"
 source "${HOMEobsforge}/ush/detect_machine.sh"
 source "${HOMEobsforge}/ush/module-setup.sh"
 module use "${HOMEobsforge}/modulefiles"


### PR DESCRIPTION
This PR fixes the sourcing paths in dev/ush/of_setup.sh to correctly reference the ush/ directory.