### PR TITLE
Correct insitu profile converter names after PR #206 provider renaming

### DIFF
--- a/parm/marine_bufr_dump_config.yaml
+++ b/parm/marine_bufr_dump_config.yaml
@@ -76,11 +76,21 @@ marinebufrdump:
          back: 4
          forward: 4
 
-    - name: insitu_profile_rama 
+    - name: insitu_profile_rama_temp 
       variables:
         - name: 'waterTemperature'
           provider_var: insitu_temp_profile_rama
           error: 0.02
+      data_format: mbuoyb
+      subsets: mbuoyb
+      source: NCEP data tank
+      data_type: rama
+      data_description: 6-hrly in situ RAMA tropical mooring profiles
+      data_provider: U.S. NOAA
+      dump_tag: mbuoyb
+
+    - name: insitu_profile_rama_saln
+      variables:
         - name: 'salinity'
           provider_var: insitu_salt_profile_rama
           error: 0.01
@@ -92,11 +102,21 @@ marinebufrdump:
       data_provider: U.S. NOAA
       dump_tag: mbuoyb
 
-    - name: insitu_profile_pirata 
+    - name: insitu_profile_pirata_temp 
       variables:
         - name: 'waterTemperature'
           provider_var: insitu_temp_profile_pirata
           error: 0.02
+      data_format: mbuoyb
+      subsets: mbuoyb
+      source: NCEP data tank
+      data_type: pirata
+      data_description: 6-hrly in situ PIRATA tropical mooring profiles
+      data_provider: U.S. NOAA
+      dump_tag: mbuoyb
+
+    - name: insitu_profile_pirata_saln
+      variables:
         - name: 'salinity'
           provider_var: insitu_salt_profile_pirata
           error: 0.01
@@ -108,11 +128,21 @@ marinebufrdump:
       data_provider: U.S. NOAA
       dump_tag: mbuoyb
 
-    - name: insitu_profile_taotriton 
+    - name: insitu_profile_taotriton_temp
       variables:
         - name: 'waterTemperature'
           provider_var: insitu_temp_profile_taotriton
           error: 0.02
+      data_format: mbuoyb
+      subsets: mbuoyb
+      source: NCEP data tank
+      data_type: taotriton
+      data_description: 6-hrly in situ TAO/TRITON tropical mooring profiles
+      data_provider: U.S. NOAA
+      dump_tag: mbuoyb
+
+    - name: insitu_profile_taotriton_saln
+      variables:
         - name: 'salinity'
           provider_var: insitu_salt_profile_taotriton
           error: 0.01


### PR DESCRIPTION
This PR addresses issue #231, which reports "No such file or directory" errors for: bufr2ioda_insitu_profile_{taotriton, rama, pirata}.py.
This PR fixes the Python converter name handling after the changes introduced in PR #206. That PR added "temp" and "saln" suffixes to each provider (e.g., taotriton_temp, taotriton_saln), but the corresponding Python scripts were not updated accordingly, resulting in runtime failures.
The changes have been fully tested and are ready to merge.

Kudos to @apchoiCMD  for identifying the cause and helping with the fix.