### PR TITLE
Add the database and processing AMSR3 sea-ice

### DIFF
--- a/parm/config.wcoss2.yaml
+++ b/parm/config.wcoss2.yaml
@@ -83,6 +83,13 @@ marinedump:
       qc config:
         min: 0.0
         max: 1.0
+    nesdis_amsr3:
+      list:
+        - icec_amsr3_north
+        - icec_amsr3_south
+      qc config:
+        min: 0.0
+        max: 1.0
     nesdis_mirs:
       list:
         - icec_amsu_ma1_l2

--- a/ush/python/pyobsforge/obsdb/nesdis_amsr3_db.py
+++ b/ush/python/pyobsforge/obsdb/nesdis_amsr3_db.py
@@ -1,0 +1,101 @@
+import os
+import glob
+from datetime import datetime
+from pyobsforge.obsdb import BaseDatabase
+
+
+class NesdisAmsr3Database(BaseDatabase):
+    """Class to manage an observation file database for data assimilation."""
+
+    def __init__(self, db_name="nesdis_amsr3.db",
+                 dcom_dir="/lfs/h1/ops/prod/dcom/",
+                 obs_dir="seaice/pda"):
+        base_dir = os.path.join(dcom_dir, '*', obs_dir)
+        super().__init__(db_name, base_dir)
+
+    def create_database(self):
+        """
+        Create the SQLite database and observation files table.
+
+        This method initializes the database with a table named `obs_files` to store metadata
+        about observation files. The table contains the following columns:
+
+        - `id`: A unique identifier for each record (auto-incremented primary key).
+        - `filename`: The full path to the observation file (must be unique).
+        - `obs_time`: The timestamp of the observation, extracted from the filename.
+        - `receipt_time`: The timestamp when the file was added to the `dcom` directory.
+        - `instrument`: The instrument used to collect the observation (e.g., AMSR3).
+        - `satellite`: The satellite from which the observation was collected (e.g., GW1).
+        - `obs_type`: The type of observation (e.g., SEAICE)
+
+        The table is created if it does not already exist.
+        """
+        query = """
+        CREATE TABLE IF NOT EXISTS obs_files (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            filename TEXT UNIQUE,
+            obs_time TIMESTAMP,
+            receipt_time TIMESTAMP,
+            instrument TEXT,
+            satellite TEXT,
+            obs_type TEXT
+        )
+        """
+        self.execute_query(query)
+
+    def parse_filename(self, filename):
+        """Extract metadata from filenames matching the AMSR3-SEAICE pattern."""
+        # Make sure the filename matches the expected pattern
+        # Pattern: AMSR3-SEAICE-NH_v1r0_ggw_s202606241343067_e202606251553342_c202606251608070.nc
+        parts = os.path.basename(filename).split('_')
+
+        # Pre-check: Must be an AMSR3-SEAICE file
+        if not parts[0].startswith("AMSR3-SEAICE"):
+            print(f"[DEBUG] Skipping non AMSR3-SEAICE file: {filename}")
+            return None
+
+        try:
+            # Extract hemisphere from the first hyphen-separated segment
+            name_parts = parts[0].split('-')
+            instrument = name_parts[0]
+            hemisphere = name_parts[2].lower()
+
+            # Determine obs_type
+            if hemisphere == "nh":
+                obs_type = "icec_amsr3_north"
+            elif hemisphere == "sh":
+                obs_type = "icec_amsr3_south"
+            else:
+                print(f"[DEBUG] Unrecognized hemisphere in filename: {filename}")
+                return None
+
+            satellite = parts[2]
+            obs_time = datetime.strptime(parts[3][1:16], "%Y%m%d%H%M%S%f")
+            receipt_time = datetime.fromtimestamp(os.path.getctime(filename))
+            return filename, obs_time, receipt_time, instrument, satellite, obs_type
+
+        except Exception as e:
+            print(f"[DEBUG] Error parsing filename {filename}: {e}")
+            return None
+
+    def ingest_files(self):
+        """Scan the directory for new NESDIS AMSR3 observation files and insert them into the database."""
+        obs_files = glob.glob(os.path.join(self.base_dir, "*.nc"))
+        print(f"Found {len(obs_files)} new files to ingest")
+
+        records_to_insert = []
+        for file in obs_files:
+            parsed_data = self.parse_filename(file)
+            if parsed_data:
+                records_to_insert.append(parsed_data)
+
+        if records_to_insert:
+            query = """
+                INSERT INTO obs_files (filename, obs_time, receipt_time, instrument, satellite, obs_type)
+                VALUES (?, ?, ?, ?, ?, ?)
+            """
+            try:
+                self.insert_records(query, records_to_insert)
+                print(f"################################ Successfully ingested {len(records_to_insert)} files into the database.")
+            except Exception as e:
+                print(f"Failed to insert records: {e}")

--- a/ush/python/pyobsforge/task/marine_prepobs.py
+++ b/ush/python/pyobsforge/task/marine_prepobs.py
@@ -40,6 +40,7 @@ class MarineObsPrep(Task):
         self.ghrsst = ProviderConfig.from_task_config("ghrsst", self.task_config)
         self.rads = ProviderConfig.from_task_config("rads", self.task_config)
         self.nesdis_amsr2 = ProviderConfig.from_task_config("nesdis_amsr2", self.task_config)
+        self.nesdis_amsr3 = ProviderConfig.from_task_config("nesdis_amsr3", self.task_config)
         self.nesdis_mirs = ProviderConfig.from_task_config("nesdis_mirs", self.task_config)
         self.nesdis_jpssrr = ProviderConfig.from_task_config("nesdis_jpssrr", self.task_config)
         self.smap = ProviderConfig.from_task_config("smap", self.task_config)
@@ -58,6 +59,7 @@ class MarineObsPrep(Task):
         self.ghrsst.db.ingest_files()
         self.rads.db.ingest_files()
         self.nesdis_amsr2.db.ingest_files()
+        self.nesdis_amsr3.db.ingest_files()
         self.nesdis_mirs.db.ingest_files()
         self.nesdis_jpssrr.db.ingest_files()
         self.smap.db.ingest_files()
@@ -162,6 +164,30 @@ class MarineObsPrep(Task):
                 'task_config': self.task_config
             }
             result = self.nesdis_amsr2.process_obs_space(**kwargs)
+            return result
+
+        # Process NESDIS_AMSR3
+        if provider == "nesdis_amsr3":
+            # Only handling "icec_amsr3_" cases
+            platform = "ggw"
+            instrument = "AMSR3"
+            satellite = "ggw"
+            # TODO(G,M): Get the window size from the config
+            window_begin = self.task_config.window_begin - timedelta(hours=30)
+            window_end = self.task_config.window_begin + timedelta(hours=6)
+            kwargs = {
+                'provider': "amsr3",
+                'obs_space': obs_space,
+                'platform': platform,
+                'instrument': instrument,
+                'satellite': satellite,
+                'obs_type': obs_space,
+                'output_file': output_file,
+                'window_begin': window_begin,
+                'window_end': window_end,
+                'task_config': self.task_config
+            }
+            result = self.nesdis_amsr3.process_obs_space(**kwargs)
             return result
 
         # Process NESDIS_MIRS

--- a/ush/python/pyobsforge/task/providers.py
+++ b/ush/python/pyobsforge/task/providers.py
@@ -2,6 +2,7 @@ from logging import getLogger
 from pyobsforge.obsdb.ghrsst_db import GhrSstDatabase
 from pyobsforge.obsdb.rads_db import RADSDatabase
 from pyobsforge.obsdb.nesdis_amsr2_db import NesdisAmsr2Database
+from pyobsforge.obsdb.nesdis_amsr3_db import NesdisAmsr3Database
 from pyobsforge.obsdb.nesdis_mirs_db import NesdisMirsDatabase
 from pyobsforge.obsdb.nesdis_jpssrr_db import NesdisJpssrrDatabase
 from pyobsforge.obsdb.smap_db import SmapDatabase
@@ -67,6 +68,8 @@ class ProviderConfig:
             db = RADSDatabase(db_name=f"{provider_name}.db", dcom_dir=task_config.DCOMROOT, obs_dir="wgrdbul/adt")
         elif provider_name == "nesdis_amsr2":
             db = NesdisAmsr2Database(db_name=f"{provider_name}.db", dcom_dir=task_config.DCOMROOT, obs_dir="seaice/pda")
+        elif provider_name == "nesdis_amsr3":
+            db = NesdisAmsr3Database(db_name=f"{provider_name}.db", dcom_dir=task_config.DCOMROOT, obs_dir="seaice/pda")
         elif provider_name == "nesdis_mirs":
             obs_dirs = [
                 "seaice_amsu",

--- a/ush/python/pyobsforge/tests/test_nesdis_amsr3_database.py
+++ b/ush/python/pyobsforge/tests/test_nesdis_amsr3_database.py
@@ -66,7 +66,7 @@ def temp_obs_dir():
 def db(temp_obs_dir):
     """Initialize test database."""
     db_path = os.path.join(temp_obs_dir, "nesdis_amsr3_test.db")
-    database = NesdisAmsr2Database(
+    database = NesdisAmsr3Database(
         db_name=db_path,
         dcom_dir=temp_obs_dir,
         obs_dir="seaice/pda"

--- a/ush/python/pyobsforge/tests/test_nesdis_amsr3_database.py
+++ b/ush/python/pyobsforge/tests/test_nesdis_amsr3_database.py
@@ -85,14 +85,14 @@ def test_create_database(db):
 
 def test_parse_valid_filename(db):
     print(glob.glob(os.path.join(db.base_dir, "*")))
-    fname = "AMSR3-SEAICE-NH_v1r0_ggw_s202606250117246_e202606260327311_c202606260345590.nc"
+    fname = "AMSR3-SEAICE-NH_v1r0_ggw_s202606250255070_e202606260504285_c202606260524550.nc"
     fname = glob.glob(os.path.join(db.base_dir, fname))[0]
     parsed = db.parse_filename(fname)
     creation_time = datetime.fromtimestamp(os.path.getctime(fname))
 
     assert parsed is not None
     assert parsed[0] == fname
-    assert parsed[1] == datetime(2026, 6, 25, 1, 17, 24)
+    assert parsed[1] == datetime(2026, 6, 25, 2, 55, 07)
     assert parsed[2] == creation_time
     assert parsed[3] == "AMSR3"
     assert parsed[4] == "ggw"

--- a/ush/python/pyobsforge/tests/test_nesdis_amsr3_database.py
+++ b/ush/python/pyobsforge/tests/test_nesdis_amsr3_database.py
@@ -92,7 +92,7 @@ def test_parse_valid_filename(db):
 
     assert parsed is not None
     assert parsed[0] == fname
-    assert parsed[1] == datetime(2026, 6, 25, 2, 55, 07)
+    assert parsed[1] == datetime(2026, 6, 25, 2, 55, 7)
     assert parsed[2] == creation_time
     assert parsed[3] == "AMSR3"
     assert parsed[4] == "ggw"

--- a/ush/python/pyobsforge/tests/test_nesdis_amsr3_database.py
+++ b/ush/python/pyobsforge/tests/test_nesdis_amsr3_database.py
@@ -1,0 +1,183 @@
+import os
+import glob
+import tempfile
+import shutil
+import sqlite3
+from datetime import datetime, timedelta
+
+import pytest
+
+from pyobsforge.obsdb.nesdis_amsr3_db import NesdisAmsr3Database  # Adjust as needed
+
+
+@pytest.fixture
+def temp_obs_dir():
+    """Create a temp directory with mock NESDIS AMSR3 NetCDF files."""
+    base_dir = tempfile.mkdtemp()
+    sub_dir = os.path.join(base_dir, "some_subdir", "seaice/pda")
+    os.makedirs(sub_dir)
+
+    # Desired datetime for file timestamps
+    mock_time = datetime(2026, 6, 25, 0, 0, 0).timestamp()
+
+    # Create mock NetCDF files
+    filenames = [
+        "AMSR3-SEAICE-NH_v1r0_ggw_s202606250117246_e202606260327311_c202606260345590.nc",
+        "AMSR3-SEAICE-NH_v1r0_ggw_s202606250255070_e202606260504285_c202606260524550.nc",
+        "AMSR3-SEAICE-NH_v1r0_ggw_s202606250432134_e202606260641184_c202606260655260.nc",
+        "AMSR3-SEAICE-NH_v1r0_ggw_s202606250609033_e202606260808203_c202606260831280.nc",
+        "AMSR3-SEAICE-NH_v1r0_ggw_s202606250745562_e202606260955282_c202606261011340.nc",
+        "AMSR3-SEAICE-NH_v1r0_ggw_s202606250923041_e202606261132526_c202606261154430.nc",
+        "AMSR3-SEAICE-NH_v1r0_ggw_s202606251100255_e202606261310290_c202606261325490.nc",
+        "AMSR3-SEAICE-NH_v1r0_ggw_s202606251237589_e202606261448159_c202606261511350.nc",
+        "AMSR3-SEAICE-NH_v1r0_ggw_s202606251415413_e202606261626149_c202606261649310.nc",
+        "AMSR3-SEAICE-NH_v1r0_ggw_s202606251553357_e202606261804542_c202606261829470.nc",
+        "AMSR3-SEAICE-NH_v1r0_ggw_s202606251731541_e202606261945082_c202606262002280.nc",
+        "AMSR3-SEAICE-NH_v1r0_ggw_s202606251911366_e202606262125461_c202606262157510.nc",
+        "AMSR3-SEAICE-NH_v1r0_ggw_s202606252052190_e202606262305435_c202606262328180.nc",
+        "AMSR3-SEAICE-NH_v1r0_ggw_s202606252232344_e202606270044379_c202606270107430.nc",
+        "AMSR3-SEAICE-SH_v1r0_ggw_s202606250117246_e202606260327311_c202606260345590.nc",
+        "AMSR3-SEAICE-SH_v1r0_ggw_s202606250255070_e202606260504285_c202606260524550.nc",
+        "AMSR3-SEAICE-SH_v1r0_ggw_s202606250432134_e202606260641184_c202606260655260.nc",
+        "AMSR3-SEAICE-SH_v1r0_ggw_s202606250609033_e202606260808203_c202606260831280.nc",
+        "AMSR3-SEAICE-SH_v1r0_ggw_s202606250745562_e202606260955282_c202606261011340.nc",
+        "AMSR3-SEAICE-SH_v1r0_ggw_s202606250923041_e202606261132526_c202606261154430.nc",
+        "AMSR3-SEAICE-SH_v1r0_ggw_s202606251100255_e202606261310290_c202606261325490.nc",
+        "AMSR3-SEAICE-SH_v1r0_ggw_s202606251237589_e202606261448159_c202606261511350.nc",
+        "AMSR3-SEAICE-SH_v1r0_ggw_s202606251415413_e202606261626149_c202606261649310.nc",
+        "AMSR3-SEAICE-SH_v1r0_ggw_s202606251553357_e202606261804542_c202606261829470.nc",
+        "AMSR3-SEAICE-SH_v1r0_ggw_s202606251731541_e202606261945082_c202606262002280.nc",
+        "AMSR3-SEAICE-SH_v1r0_ggw_s202606251911366_e202606262125461_c202606262157510.nc",
+        "AMSR3-SEAICE-SH_v1r0_ggw_s202606252052190_e202606262305435_c202606262328180.nc",
+        "AMSR3-SEAICE-SH_v1r0_ggw_s202606252232344_e202606270044379_c202606270107430.nc",
+        "invalid_file.nc"
+    ]
+    for fname in filenames:
+        fname_tmp = os.path.join(sub_dir, fname)
+        with open(fname_tmp, "w") as f:
+            f.write("fake content")
+        os.utime(fname_tmp, (mock_time, mock_time))  # (access_time, modification_time)
+
+    yield base_dir
+    shutil.rmtree(base_dir)
+
+
+@pytest.fixture
+def db(temp_obs_dir):
+    """Initialize test database."""
+    db_path = os.path.join(temp_obs_dir, "nesdis_amsr3_test.db")
+    database = NesdisAmsr2Database(
+        db_name=db_path,
+        dcom_dir=temp_obs_dir,
+        obs_dir="seaice/pda"
+    )
+    return database
+
+
+def test_create_database(db):
+    db.create_database()
+    conn = sqlite3.connect(db.db_name)
+    cursor = conn.cursor()
+    cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='obs_files'")
+    assert cursor.fetchone() is not None
+    conn.close()
+
+
+def test_parse_valid_filename(db):
+    print(glob.glob(os.path.join(db.base_dir, "*")))
+    fname = "AMSR3-SEAICE-NH_v1r0_ggw_s202606250117246_e202606260327311_c202606260345590.nc"
+    fname = glob.glob(os.path.join(db.base_dir, fname))[0]
+    parsed = db.parse_filename(fname)
+    creation_time = datetime.fromtimestamp(os.path.getctime(fname))
+
+    assert parsed is not None
+    assert parsed[0] == fname
+    assert parsed[1] == datetime(2026, 6, 25, 1, 17, 24)
+    assert parsed[2] == creation_time
+    assert parsed[3] == "AMSR3"
+    assert parsed[4] == "ggw"
+    # assert parsed[5] == "SEAICE"
+    assert parsed[5] == "icec_amsr3_north"
+
+
+def test_parse_invalid_filename(db):
+    assert db.parse_filename("junk.nc") is None
+    assert db.parse_filename("AMSR3-SEAICE-NH_v1r0_ggw_invalid.nc") is None
+
+
+def test_ingest_files(db):
+    db.ingest_files()
+    conn = sqlite3.connect(db.db_name)
+    cursor = conn.cursor()
+    cursor.execute("SELECT COUNT(*) FROM obs_files")
+    count = cursor.fetchone()[0]
+    conn.close()
+    assert count == 28, "Should ingest 28 valid AMSR3 files"
+
+
+def test_get_valid_files(db):
+    db.ingest_files()
+    da_cycle = "20260625060000"
+    window_begin = datetime.strptime(da_cycle, "%Y%m%d%H%M%S") - timedelta(hours=3)
+    window_end = datetime.strptime(da_cycle, "%Y%m%d%H%M%S") + timedelta(hours=3)
+    dst_dir = 'icec'
+    # Test for AMSR3 ICEC
+    valid_files_north = db.get_valid_files(window_begin=window_begin,
+                                           window_end=window_end,
+                                           dst_dir=dst_dir,
+                                           instrument="AMSR3",
+                                           satellite="ggw",
+                                           obs_type="icec_amsr2_north")
+
+    valid_files_south = db.get_valid_files(window_begin=window_begin,
+                                           window_end=window_end,
+                                           dst_dir=dst_dir,
+                                           instrument="AMSR3",
+                                           satellite="ggw",
+                                           obs_type="icec_amsr2_south")
+
+    valid_files = valid_files_north + valid_files_south
+
+    # Files at 10:00 and 12:00 are within +/- 3h of 00:00
+    assert any("202606250609" in f for f in valid_files)
+    assert any("202606250745" in f for f in valid_files)
+    assert all("202606250923" not in f for f in valid_files)
+
+    print("Valid files found:", len(valid_files))
+    for f in valid_files:
+        print(" -", f)
+    assert len(valid_files) == 6
+
+
+def test_get_valid_files_receipt(db):
+    db.ingest_files()
+    da_cycle = "20260625060000"
+    window_begin = datetime.strptime(da_cycle, "%Y%m%d%H%M%S") - timedelta(hours=3)
+    window_end = datetime.strptime(da_cycle, "%Y%m%d%H%M%S") + timedelta(hours=3)
+    dst_dir = 'icec'
+
+    # Test for AMSR3 ICEC
+    valid_files_north = db.get_valid_files(window_begin=window_begin,
+                                           window_end=window_end,
+                                           dst_dir=dst_dir,
+                                           instrument="AMSR3",
+                                           satellite="ggw",
+                                           obs_type="icec_amsr2_north",
+                                           check_receipt="gfs")
+
+    valid_files_south = db.get_valid_files(window_begin=window_begin,
+                                           window_end=window_end,
+                                           dst_dir=dst_dir,
+                                           instrument="AMSR3",
+                                           satellite="ggw",
+                                           obs_type="icec_amsr2_south",
+                                           check_receipt="gfs")
+
+    valid_files = valid_files_north + valid_files_south
+
+    print("Valid files found:", len(valid_files))
+    for f in valid_files:
+        print(" -", f)
+
+    # TODO (G): Giving up for now on trying to mock the receipt time, will revisit later
+    assert len(valid_files) == 6

--- a/ush/python/pyobsforge/tests/test_nesdis_amsr3_database.py
+++ b/ush/python/pyobsforge/tests/test_nesdis_amsr3_database.py
@@ -127,14 +127,14 @@ def test_get_valid_files(db):
                                            dst_dir=dst_dir,
                                            instrument="AMSR3",
                                            satellite="ggw",
-                                           obs_type="icec_amsr2_north")
+                                           obs_type="icec_amsr3_north")
 
     valid_files_south = db.get_valid_files(window_begin=window_begin,
                                            window_end=window_end,
                                            dst_dir=dst_dir,
                                            instrument="AMSR3",
                                            satellite="ggw",
-                                           obs_type="icec_amsr2_south")
+                                           obs_type="icec_amsr3_south")
 
     valid_files = valid_files_north + valid_files_south
 
@@ -162,7 +162,7 @@ def test_get_valid_files_receipt(db):
                                            dst_dir=dst_dir,
                                            instrument="AMSR3",
                                            satellite="ggw",
-                                           obs_type="icec_amsr2_north",
+                                           obs_type="icec_amsr3_north",
                                            check_receipt="gfs")
 
     valid_files_south = db.get_valid_files(window_begin=window_begin,
@@ -170,7 +170,7 @@ def test_get_valid_files_receipt(db):
                                            dst_dir=dst_dir,
                                            instrument="AMSR3",
                                            satellite="ggw",
-                                           obs_type="icec_amsr2_south",
+                                           obs_type="icec_amsr3_south",
                                            check_receipt="gfs")
 
     valid_files = valid_files_north + valid_files_south

--- a/utils/preproc/IcecAmsr3Ioda.h
+++ b/utils/preproc/IcecAmsr3Ioda.h
@@ -1,0 +1,148 @@
+#pragma once
+
+#include <ctime>
+#include <iomanip>
+#include <iostream>
+#include <map>
+#include <netcdf>    // NOLINT (using C API)
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "eckit/config/LocalConfiguration.h"
+
+#include <Eigen/Dense>    // NOLINT
+
+#include "ioda/../../../../core/IodaUtils.h"
+#include "ioda/Group.h"
+#include "ioda/ObsGroup.h"
+
+#include "oops/util/dateFunctions.h"
+
+#include "NetCDFToIodaConverter.h"
+
+namespace obsforge {
+
+  class IcecAmsr3Ioda : public NetCDFToIodaConverter {
+   public:
+    explicit IcecAmsr3Ioda(const eckit::Configuration & fullConfig, const eckit::mpi::Comm & comm)
+      : NetCDFToIodaConverter(fullConfig, comm) {
+      variable_ = "seaIceFraction";
+    }
+
+    // Read netcdf file and populate iodaVars
+    obsforge::preproc::iodavars::IodaVars providerToIodaVars(const std::string fileName) final {
+      oops::Log::info() << "Processing files provided by the AMSR3" << std::endl;
+
+      //  Abort the case where the 'window begin & window end' key is not found
+      ASSERT(fullConfig_.has("window begin"));
+      ASSERT(fullConfig_.has("window end"));
+
+      // read as string
+      std::string windowBeginStr, windowEndStr;
+      fullConfig_.get("window begin", windowBeginStr);
+      fullConfig_.get("window end", windowEndStr);
+
+      // Open the NetCDF file in read-only mode
+      netCDF::NcFile ncFile(fileName, netCDF::NcFile::read);
+      oops::Log::info() << "Reading... " << fileName << std::endl;
+
+      // Get the number of obs in the file
+      int dimxSize = ncFile.getDim("Number_of_X_Dimension").getSize();
+      int dimySize = ncFile.getDim("Number_of_Y_Dimension").getSize();
+      int dimTimeSize = ncFile.getDim("Time_Dimension").getSize();
+      int nobs = dimxSize * dimySize;
+      int ntimes = dimxSize * dimySize * dimTimeSize;
+
+      // Set the int metadata names
+      std::vector<std::string> intMetadataNames = {"oceanBasin"};
+
+      // Set the float metadata name
+      std::vector<std::string> floatMetadataNames = {};
+
+      // Create instance of iodaVars object
+      obsforge::preproc::iodavars::IodaVars iodaVars(nobs, 1, floatMetadataNames, intMetadataNames);
+
+      oops::Log::debug() << "--- iodaVars.location_: " << iodaVars.location_ << std::endl;
+
+      // Read non-optional metadata: longitude and latitude
+      std::vector<float> oneDimLatVal(iodaVars.location_);
+      ncFile.getVar("Latitude").getVar(oneDimLatVal.data());
+
+      std::vector<float> oneDimLonVal(iodaVars.location_);
+      ncFile.getVar("Longitude").getVar(oneDimLonVal.data());
+
+      // Read Quality Flags as a preQc
+      std::vector<int64_t> oneDimFlagsVal(iodaVars.location_);
+      ncFile.getVar("Flags").getVar(oneDimFlagsVal.data());
+
+      // Get Ice_Concentration obs values
+      std::vector<int> oneDimObsVal(iodaVars.location_);
+      ncFile.getVar("NASA_Team_2_Ice_Concentration").getVar(oneDimObsVal.data());
+
+      // Read and process the dateTime
+      std::vector<int> oneTmpdateTimeVal(ntimes);
+      ncFile.getVar("Scan_Time").getVar(oneTmpdateTimeVal.data());
+      iodaVars.referenceDate_ = "seconds since 1970-01-01T00:00:00Z";
+
+      // Set epoch time for AMSR3_ICEC
+      util::DateTime epochDtime("1970-01-01T00:00:00Z");
+
+      // Compute seconds of windowBegin and windowEnd since epoch
+      util::DateTime windowBegin(windowBeginStr);
+      util::DateTime windowEnd(windowEndStr);
+      int64_t winBeginSecondsSinceEpoch
+           = ioda::convertDtimeToTimeOffsets(epochDtime, {windowBegin})[0];
+      int64_t winEndSecondsSinceEpoch
+           = ioda::convertDtimeToTimeOffsets(epochDtime, {windowEnd})[0];
+
+      // Compute seconds of observations  since epoch
+      size_t index = 0;
+      for (int i = 0; i < ntimes; i += dimTimeSize) {
+        int year = oneTmpdateTimeVal[i];
+        int month = oneTmpdateTimeVal[i+1];
+        int day = oneTmpdateTimeVal[i+2];
+        int hour = oneTmpdateTimeVal[i+3];
+        int minute =  oneTmpdateTimeVal[i+4];
+        int second = static_cast<int>(oneTmpdateTimeVal[i+5]);
+
+        // Avoid crash util in ioda::convertDtimeToTimeOffsets
+        if (year == -9999 || month == -9999 || day == -9999 ||
+          hour == -9999 || minute == -9999 || second == -9999) {
+          year = month = day = hour = minute = second = 0;
+        }
+
+        util::DateTime dateTime(year, month, day, hour, minute, second);
+
+        // Convert Obs DateTime objects to epoch time offsets in seconds
+        // 0000-00-00T00:00:00Z will be converterd to negative seconds
+        int64_t timeOffsets
+           = ioda::convertDtimeToTimeOffsets(epochDtime, {dateTime})[0];
+
+        // Update datetime Eigen Arrays
+        iodaVars.datetime_(index) = timeOffsets;
+        index++;
+      }
+
+      // Update non-optional Eigen arrays
+      for (int i = 0; i < iodaVars.location_; i++) {
+        iodaVars.longitude_(i) = oneDimLonVal[i];
+        iodaVars.latitude_(i) = oneDimLatVal[i];
+        iodaVars.obsVal_(i) = static_cast<float>(oneDimObsVal[i]*0.01);
+        iodaVars.obsError_(i) = 0.1;  // Do something for obs error
+        iodaVars.preQc_(i) = oneDimFlagsVal[i];
+        // Store optional metadata, set ocean basins to -999 for now
+        iodaVars.intMetadata_.row(i) << -999;
+      }
+
+      // basic test for iodaVars.trim
+      Eigen::Array<bool, Eigen::Dynamic, 1> mask =
+          (iodaVars.obsVal_ >= 0.0) &&
+          (iodaVars.datetime_ >= winBeginSecondsSinceEpoch) &&
+          (iodaVars.datetime_ <= winEndSecondsSinceEpoch);
+      iodaVars.trim(mask);
+
+      return iodaVars;
+    };
+  };  // class IcecAmsr3Ioda
+}  // namespace obsforge

--- a/utils/preproc/applications/obsprovider2ioda.h
+++ b/utils/preproc/applications/obsprovider2ioda.h
@@ -9,6 +9,7 @@
 #include "../Ghrsst2Ioda.h"
 #include "../IcecAbi2Ioda.h"
 #include "../IcecAmsr2Ioda.h"
+#include "../IcecAmsr3Ioda.h"
 #include "../IcecJpssrr2Ioda.h"
 #include "../IcecMirs2Ioda.h"
 #include "../InsituAll2ioda.h"
@@ -57,6 +58,9 @@ namespace obsforge {
         conv2ioda.writeToIoda();
       } else if (provider == "AMSR2") {
         IcecAmsr2Ioda conv2ioda(fullConfig, this->getComm());
+        conv2ioda.writeToIoda();
+      } else if (provider == "AMSR3") {
+        IcecAmsr3Ioda conv2ioda(fullConfig, this->getComm());
         conv2ioda.writeToIoda();
       } else if (provider == "MIRS") {
         IcecMirs2Ioda conv2ioda(fullConfig, this->getComm());


### PR DESCRIPTION
This PR includes;

- make amsr3 database from dcom and process the amsr3 sea ice concentration to ioda format observation like amsr2

- mostly using amsr2 ioda converter, and populate them into `icec`

AMSR2 is going to be decommissioned August 31, 2026, presumably, obsforge will run with amsr3 in August.