### PR TITLE
Add ICESat-2 freeboard IODA converter

### DIFF
--- a/utils/preproc/CMakeLists.txt
+++ b/utils/preproc/CMakeLists.txt
@@ -2,6 +2,7 @@
 add_library(netcdf2ioda
     IcecAmsr2Ioda.h
     IcecAbi2Ioda.h
+    IcefbIcesat2Ioda.h
     Ghrsst2Ioda.h
     Viirsaod2Ioda.h
     util.h

--- a/utils/preproc/IcefbIcesat2Ioda.h
+++ b/utils/preproc/IcefbIcesat2Ioda.h
@@ -1,0 +1,314 @@
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <limits>
+#include <netcdf>    // NOLINT (using C API)
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "eckit/config/LocalConfiguration.h"
+
+#include <Eigen/Dense>    // NOLINT
+
+#include "ioda/core/IodaUtils.h"
+#include "ioda/Group.h"
+#include "ioda/ObsGroup.h"
+
+#include "oops/util/dateFunctions.h"
+
+#include "NetCDFToIodaConverter.h"
+
+namespace obsforge {
+
+  class IcefbIcesat2Ioda : public NetCDFToIodaConverter {
+   public:
+    explicit IcefbIcesat2Ioda(const eckit::Configuration & fullConfig, const eckit::mpi::Comm & comm)
+      : NetCDFToIodaConverter(fullConfig, comm) {
+      variable_ = "seaIceFreeboard";
+
+      if (fullConfig_.has("thin stride")) {
+        fullConfig_.get("thin stride", thinStride_);
+      }
+      ASSERT(thinStride_ >= 1);
+
+      if (fullConfig_.has("min freeboard")) {
+        fullConfig_.get("min freeboard", minFreeboard_);
+        useMinFreeboard_ = true;
+      }
+      if (fullConfig_.has("max freeboard")) {
+        fullConfig_.get("max freeboard", maxFreeboard_);
+        useMaxFreeboard_ = true;
+      }
+      if (fullConfig_.has("max quality flag")) {
+        fullConfig_.get("max quality flag", maxQualityFlag_);
+      }
+      if (fullConfig_.has("keep invalid quality flag")) {
+        fullConfig_.get("keep invalid quality flag", keepInvalidQualityFlag_);
+      }
+      if (fullConfig_.has("default obs error")) {
+        fullConfig_.get("default obs error", defaultObsError_);
+      }
+
+      northOutputFilename_ = outputFilenameWithPole(outputFilename_, "north");
+      southOutputFilename_ = outputFilenameWithPole(outputFilename_, "south");
+      if (fullConfig_.has("north output file")) {
+        fullConfig_.get("north output file", northOutputFilename_);
+      }
+      if (fullConfig_.has("south output file")) {
+        fullConfig_.get("south output file", southOutputFilename_);
+      }
+    }
+
+    void writeToIoda() {
+      if (inputFilenames_.empty()) {
+        writeEmptyIodaFile(northOutputFilename_);
+        writeEmptyIodaFile(southOutputFilename_);
+        return;
+      }
+
+      obsforge::preproc::iodavars::IodaVars iodaVarsAll = collectIodaVars();
+      if (comm_.rank() == 0) {
+        obsforge::preproc::iodavars::IodaVars northVars = iodaVarsAll;
+        Eigen::Array<bool, Eigen::Dynamic, 1> northMask = northVars.latitude_ >= 0.0f;
+        northVars.trim(northMask);
+        northVars.strGlobalAttr_["pole"] = "north";
+        writeIodaFile(northOutputFilename_, &northVars);
+
+        obsforge::preproc::iodavars::IodaVars southVars = iodaVarsAll;
+        Eigen::Array<bool, Eigen::Dynamic, 1> southMask = southVars.latitude_ < 0.0f;
+        southVars.trim(southMask);
+        southVars.strGlobalAttr_["pole"] = "south";
+        writeIodaFile(southOutputFilename_, &southVars);
+      }
+    }
+
+    // Read ATL10 granule and populate IodaVars.
+    obsforge::preproc::iodavars::IodaVars providerToIodaVars(const std::string fileName) final {
+      oops::Log::info() << "Processing files provided by ICESat-2 ATL10" << std::endl;
+      oops::Log::info() << "Reading... " << fileName << std::endl;
+
+      netCDF::NcFile ncFile(fileName, netCDF::NcFile::read);
+
+      std::vector<float> latValues;
+      std::vector<float> lonValues;
+      std::vector<int64_t> datetimeValues;
+      std::vector<float> freeboardValues;
+      std::vector<float> errorValues;
+      std::vector<int> preQcValues;
+      std::vector<float> confidenceValues;
+      std::vector<int> beamValues;
+
+      const int64_t atl10EpochOffset = atl10EpochOffsetSeconds();
+      const int64_t windowBeginSeconds = epochOffsetSeconds(windowBegin_);
+      const int64_t windowEndSeconds = epochOffsetSeconds(windowEnd_);
+
+      for (const auto & beam : beams_) {
+        netCDF::NcGroup beamGroup = ncFile.getGroup(beam);
+        if (beamGroup.isNull()) {
+          continue;
+        }
+
+        netCDF::NcGroup segment = beamGroup.getGroup("freeboard_segment");
+        if (segment.isNull()) {
+          continue;
+        }
+
+        std::vector<double> lat = readSampled1D<double>(segment, "latitude");
+        std::vector<double> lon = readSampled1D<double>(segment, "longitude");
+        std::vector<double> deltaTime = readSampled1D<double>(segment, "delta_time");
+        std::vector<float> freeboard = readSampled1D<float>(segment, "beam_fb_height");
+        std::vector<float> uncertainty = readSampled1D<float>(segment, "beam_fb_unc");
+        std::vector<int> qualityFlag = readSampled1D<int>(segment, "beam_fb_quality_flag");
+        std::vector<float> confidence = readSampled1D<float>(segment, "beam_fb_confidence");
+
+        const size_t nobs = minimumSize({lat.size(), lon.size(), deltaTime.size(),
+                                         freeboard.size(), uncertainty.size(),
+                                         qualityFlag.size(), confidence.size()});
+        const int beamId = beamIdentifier(beam);
+
+        for (size_t i = 0; i < nobs; i++) {
+          if (!validLatitude(lat[i]) || !validLongitude(lon[i]) ||
+              !validDouble(deltaTime[i]) || !validFloat(freeboard[i]) ||
+              !validQualityFlag(qualityFlag[i])) {
+            continue;
+          }
+          const int64_t datetime = atl10EpochOffset + static_cast<int64_t>(std::llround(deltaTime[i]));
+          if (datetime < windowBeginSeconds || datetime > windowEndSeconds) {
+            continue;
+          }
+          if (useMinFreeboard_ && freeboard[i] < minFreeboard_) {
+            continue;
+          }
+          if (useMaxFreeboard_ && freeboard[i] > maxFreeboard_) {
+            continue;
+          }
+
+          latValues.push_back(static_cast<float>(lat[i]));
+          lonValues.push_back(static_cast<float>(lon[i]));
+          datetimeValues.push_back(datetime);
+          freeboardValues.push_back(freeboard[i]);
+          errorValues.push_back(validError(uncertainty[i]) ? uncertainty[i] : defaultObsError_);
+          preQcValues.push_back(qualityFlag[i]);
+          confidenceValues.push_back(validFloat(confidence[i]) ? confidence[i] : missingFloat_);
+          beamValues.push_back(beamId);
+        }
+      }
+
+      std::vector<std::string> floatMetadataNames = {"freeboardConfidence"};
+      std::vector<std::string> intMetadataNames = {"beam", "oceanBasin"};
+      obsforge::preproc::iodavars::IodaVars iodaVars(latValues.size(), 1,
+                                                     floatMetadataNames,
+                                                     intMetadataNames);
+      iodaVars.referenceDate_ = "seconds since 1970-01-01T00:00:00Z";
+      iodaVars.strGlobalAttr_["platform"] = "ICESat-2";
+      iodaVars.strGlobalAttr_["instrument"] = "ATLAS";
+      iodaVars.strGlobalAttr_["source"] = "ATL10 L3A Sea Ice Freeboard";
+      iodaVars.strGlobalAttr_["beam_index"] = beamIndexDescription();
+
+      for (int i = 0; i < iodaVars.location_; i++) {
+        iodaVars.latitude_(i) = latValues[i];
+        iodaVars.longitude_(i) = lonValues[i];
+        iodaVars.datetime_(i) = datetimeValues[i];
+        iodaVars.obsVal_(i) = freeboardValues[i];
+        iodaVars.obsError_(i) = errorValues[i];
+        iodaVars.preQc_(i) = preQcValues[i];
+        iodaVars.floatMetadata_.row(i) << confidenceValues[i];
+        iodaVars.intMetadata_.row(i) << beamValues[i], -999;
+      }
+
+      oops::Log::info() << "ICESat-2 ATL10 valid observations: "
+                        << iodaVars.location_ << std::endl;
+      return iodaVars;
+    }
+
+   private:
+    template <typename T>
+    std::vector<T> readSampled1D(const netCDF::NcGroup & group, const std::string & variableName) const {
+      netCDF::NcVar variable = group.getVar(variableName);
+      if (variable.isNull()) {
+        oops::Log::warning() << "Missing ATL10 variable: " << variableName << std::endl;
+        return {};
+      }
+
+      const std::vector<netCDF::NcDim> dims = variable.getDims();
+      if (dims.size() != 1) {
+        oops::Log::warning() << "ATL10 variable has unexpected rank, skipping: "
+                              << variableName << std::endl;
+        return {};
+      }
+      const size_t dimSize = dims[0].getSize();
+      const size_t sampledSize = (dimSize + thinStride_ - 1) / thinStride_;
+      std::vector<T> values(sampledSize);
+
+      if (sampledSize == 0) {
+        return values;
+      }
+
+      const std::vector<size_t> start = {0};
+      const std::vector<size_t> count = {sampledSize};
+      const std::vector<std::ptrdiff_t> stride = {thinStride_};
+      variable.getVar(start, count, stride, values.data());
+      return values;
+    }
+
+    int64_t epochOffsetSeconds(const util::DateTime & dateTime) const {
+      util::DateTime epochDtime("1970-01-01T00:00:00Z");
+      return ioda::convertDtimeToTimeOffsets(epochDtime, {dateTime})[0];
+    }
+
+    int64_t atl10EpochOffsetSeconds() const {
+      util::DateTime atl10Epoch("2018-01-01T00:00:00Z");
+      return epochOffsetSeconds(atl10Epoch);
+    }
+
+    static bool validFloat(const float value) {
+      return std::isfinite(value) && std::abs(value) < 1.0e20f;
+    }
+
+    static bool validDouble(const double value) {
+      return std::isfinite(value) && std::abs(value) < 1.0e20;
+    }
+
+    static bool validLatitude(const double value) {
+      return validDouble(value) && value >= -90.0 && value <= 90.0;
+    }
+
+    static bool validLongitude(const double value) {
+      return validDouble(value) && value >= -180.0 && value <= 180.0;
+    }
+
+    bool validQualityFlag(const int value) const {
+      if (keepInvalidQualityFlag_) {
+        return true;
+      }
+      return value >= 1 && value <= maxQualityFlag_;
+    }
+
+    bool validError(const float value) const {
+      return validFloat(value) && value >= 0.0f;
+    }
+
+    static size_t minimumSize(const std::vector<size_t> & sizes) {
+      size_t result = std::numeric_limits<size_t>::max();
+      for (const size_t size : sizes) {
+        result = std::min(result, size);
+      }
+      return result == std::numeric_limits<size_t>::max() ? 0 : result;
+    }
+
+    static int beamIdentifier(const std::string & beam) {
+      if (beam == "gt1l") return 11;
+      if (beam == "gt1r") return 12;
+      if (beam == "gt2l") return 21;
+      if (beam == "gt2r") return 22;
+      if (beam == "gt3l") return 31;
+      if (beam == "gt3r") return 32;
+      return -1;
+    }
+
+    static std::string beamIndexDescription() {
+      std::stringstream description;
+      description << "gt1l=11 gt1r=12 gt2l=21 gt2r=22 gt3l=31 gt3r=32";
+      return description.str();
+    }
+
+    static std::string outputFilenameWithPole(const std::string & outputFilename,
+                                              const std::string & pole) {
+      const std::string iodaExtension = ".ioda";
+      size_t pos = outputFilename.rfind(iodaExtension);
+      if (pos != std::string::npos) {
+        return outputFilename.substr(0, pos) + "_" + pole + outputFilename.substr(pos);
+      }
+
+      const std::string ncExtension = ".nc";
+      pos = outputFilename.rfind(ncExtension);
+      if (pos != std::string::npos) {
+        return outputFilename.substr(0, pos) + "_" + pole + outputFilename.substr(pos);
+      }
+
+      return outputFilename + "_" + pole;
+    }
+
+    static constexpr float missingFloat_ = std::numeric_limits<float>::max();
+    static constexpr std::array<const char *, 6> beams_ = {
+      "gt1l", "gt1r", "gt2l", "gt2r", "gt3l", "gt3r"
+    };
+
+    int thinStride_ = 1;
+    bool useMinFreeboard_ = false;
+    bool useMaxFreeboard_ = false;
+    double minFreeboard_ = 0.0;
+    double maxFreeboard_ = 0.0;
+    int maxQualityFlag_ = 5;
+    bool keepInvalidQualityFlag_ = false;
+    float defaultObsError_ = 0.5f;
+    std::string northOutputFilename_;
+    std::string southOutputFilename_;
+  };  // class IcefbIcesat2Ioda
+}  // namespace obsforge

--- a/utils/preproc/NetCDFToIodaConverter.h
+++ b/utils/preproc/NetCDFToIodaConverter.h
@@ -52,32 +52,25 @@ namespace obsforge {
 
 
 
-    // Method to write out a IODA file (writter called in destructor)
+    // Method to write out a IODA file.
     void writeToIoda() {
+      if (inputFilenames_.empty()) {
+        writeEmptyIodaFile(outputFilename_);
+        return;
+      }
+
+      obsforge::preproc::iodavars::IodaVars iodaVarsAll = collectIodaVars();
+      if (comm_.rank() == 0) {
+        writeIodaFile(outputFilename_, &iodaVarsAll);
+      }
+    }
+
+   protected:
+    obsforge::preproc::iodavars::IodaVars collectIodaVars() {
       // Extract ioda variables from the provider's files
       int myrank  = comm_.rank();
       int nobs(0);
       int nchan(0);
-
-      // Handle empty input file list gracefully
-      // Some obs types (e.g. BATHY, RAMA) may have zero input files when concatenating
-      if (inputFilenames_.empty()) {
-       oops::Log::warning() << "writeToIoda: No input files found for "
-                             << outputFilename_
-                             << " — creating empty output file." << std::endl;
-        if (oops::mpi::world().rank() == 0) {
-          ioda::Group group =
-            ioda::Engines::HH::createFile(outputFilename_,
-                                         ioda::Engines::BackendCreateModes::Truncate_If_Exists);
-         ioda::NewDimensionScales_t newDims {
-            ioda::NewDimensionScale<int>("Location", 0)
-          };
-         ioda::ObsGroup ogrp = ioda::ObsGroup::generate(group, newDims);
-         oops::Log::info() << "writeToIoda: empty output file created: "
-                            << outputFilename_ << std::endl;
-        }
-        return;
-      }
 
       // Handle MPI PE count > input file count
       // Each PE processes at least one file, excess PEs get no files
@@ -85,30 +78,47 @@ namespace obsforge {
         oops::Log::warning() << "writeToIoda: More MPI tasks (" << comm_.size()
                              << ") than input files (" << inputFilenames_.size()
                              << ") for " << outputFilename_
-                             << " — excess PEs will be idle." << std::endl;
+                             << " - excess PEs will be idle." << std::endl;
       }
-
 
       // Read the provider's netcdf file
       obsforge::preproc::iodavars::IodaVars iodaVars;
 
       if (myrank < static_cast<int>(inputFilenames_.size())) {
-       iodaVars = providerToIodaVars(inputFilenames_[myrank]);
-       for (int i = myrank + comm_.size(); i < inputFilenames_.size(); i += comm_.size()) {
-        iodaVars.append(providerToIodaVars(inputFilenames_[i]));
-        oops::Log::info() << " appending: " << inputFilenames_[i] << std::endl;
-        oops::Log::info() << " obs count: " << iodaVars.location_ << std::endl;
-        oops::Log::test() << "Reading: " << inputFilenames_ << std::endl;
+        iodaVars = providerToIodaVars(inputFilenames_[myrank]);
+        for (int i = myrank + comm_.size(); i < inputFilenames_.size(); i += comm_.size()) {
+          iodaVars.append(providerToIodaVars(inputFilenames_[i]));
+          oops::Log::info() << " appending: " << inputFilenames_[i] << std::endl;
+          oops::Log::info() << " obs count: " << iodaVars.location_ << std::endl;
+          oops::Log::test() << "Reading: " << inputFilenames_ << std::endl;
         }
       }
 
       nobs = iodaVars.location_;
       nchan = iodaVars.channel_;
+      int nfMetadata = iodaVars.nfMetadata_;
+      int niMetadata = iodaVars.niMetadata_;
 
 
       // Get the total number of obs across pe's
       int nobsAll(0);
       comm_.allReduce(nobs, nobsAll, eckit::mpi::sum());
+      int nfMetadataAll(0);
+      comm_.allReduce(nfMetadata, nfMetadataAll, eckit::mpi::max());
+      int niMetadataAll(0);
+      comm_.allReduce(niMetadata, niMetadataAll, eckit::mpi::max());
+
+      if (iodaVars.nfMetadata_ != nfMetadataAll) {
+        iodaVars.nfMetadata_ = nfMetadataAll;
+        iodaVars.floatMetadata_.resize(iodaVars.location_, nfMetadataAll);
+        iodaVars.floatMetadata_.setZero();
+      }
+      if (iodaVars.niMetadata_ != niMetadataAll) {
+        iodaVars.niMetadata_ = niMetadataAll;
+        iodaVars.intMetadata_.resize(iodaVars.location_, niMetadataAll);
+        iodaVars.intMetadata_.setZero();
+      }
+
       obsforge::preproc::iodavars::IodaVars iodaVarsAll(nobsAll,
                                     nchan,
                                     iodaVars.floatMetadataName_,
@@ -122,132 +132,185 @@ namespace obsforge {
       gatherObs(iodaVars.obsError_, iodaVarsAll.obsError_);
       gatherObs(iodaVars.preQc_, iodaVarsAll.preQc_);
 
+      for (int count = 0; count < nfMetadataAll; count++) {
+        Eigen::ArrayXf metadataPe = iodaVars.floatMetadata_.col(count);
+        Eigen::ArrayXf metadataAll(iodaVarsAll.location_);
+        gatherObs(metadataPe, metadataAll);
+        if (comm_.rank() == 0) {
+          iodaVarsAll.floatMetadata_.col(count) = metadataAll;
+        }
+      }
+
+      for (int count = 0; count < niMetadataAll; count++) {
+        Eigen::ArrayXi metadataPe = iodaVars.intMetadata_.col(count);
+        Eigen::ArrayXi metadataAll(iodaVarsAll.location_);
+        gatherObs(metadataPe, metadataAll);
+        if (comm_.rank() == 0) {
+          iodaVarsAll.intMetadata_.col(count) = metadataAll;
+        }
+      }
+
+      int localHasOriginalDatetime = iodaVars.originalDatetime_.size() == 0 ? 0 : 1;
+      int hasOriginalDatetime(0);
+      comm_.allReduce(localHasOriginalDatetime, hasOriginalDatetime, eckit::mpi::max());
+      if (hasOriginalDatetime > 0) {
+        iodaVarsAll.originalDatetime_.resize(iodaVarsAll.location_);
+        gatherObs(iodaVars.originalDatetime_, iodaVarsAll.originalDatetime_);
+      }
+
+      if (comm_.rank() == 0) {
+        iodaVarsAll.referenceDate_ = iodaVars.referenceDate_;
+        iodaVarsAll.channelValues_ = iodaVars.channelValues_;
+        iodaVarsAll.strGlobalAttr_ = iodaVars.strGlobalAttr_;
+      }
+
+      return iodaVarsAll;
+    }
+
+    void writeEmptyIodaFile(const std::string & outputFilename) {
+      oops::Log::warning() << "writeToIoda: No input files found for "
+                           << outputFilename
+                           << " - creating empty output file." << std::endl;
+      if (comm_.rank() == 0) {
+        ioda::Group group =
+          ioda::Engines::HH::createFile(outputFilename,
+                                        ioda::Engines::BackendCreateModes::Truncate_If_Exists);
+        ioda::NewDimensionScales_t newDims {
+          ioda::NewDimensionScale<int>("Location", 0)
+        };
+        ioda::ObsGroup ogrp = ioda::ObsGroup::generate(group, newDims);
+        oops::Log::info() << "writeToIoda: empty output file created: "
+                          << outputFilename << std::endl;
+      }
+    }
+
+    void writeIodaFile(const std::string & outputFilename,
+                       obsforge::preproc::iodavars::IodaVars * iodaVars) {
+      if (comm_.rank() != 0) {
+        return;
+      }
+      ASSERT(iodaVars != nullptr);
 
       // Create empty group backed by HDF file
-      if (oops::mpi::world().rank() == 0) {
-        ioda::Group group =
-          ioda::Engines::HH::createFile(outputFilename_,
-                                        ioda::Engines::BackendCreateModes::Truncate_If_Exists);
+      ioda::Group group =
+        ioda::Engines::HH::createFile(outputFilename,
+                                      ioda::Engines::BackendCreateModes::Truncate_If_Exists);
 
-        // Update the group with the location dimension
-        ioda::NewDimensionScales_t
-          newDims {ioda::NewDimensionScale<int>("Location", iodaVarsAll.location_)};
+      // Update the group with the location dimension
+      ioda::NewDimensionScales_t
+        newDims {ioda::NewDimensionScale<int>("Location", iodaVars->location_)};
 
-        // Update the group with the location and channel dimension (if channel value is assigned)
-        if (iodaVars.channelValues_(0) > 0) {
-           newDims = {
-                 ioda::NewDimensionScale<int>("Location", iodaVarsAll.location_),
-                 ioda::NewDimensionScale<int>("Channel", iodaVarsAll.channel_)
-           };
-        }
-        ioda::ObsGroup ogrp = ioda::ObsGroup::generate(group, newDims);
+      // Update the group with the location and channel dimension (if channel value is assigned)
+      if (iodaVars->channelValues_(0) > 0) {
+         newDims = {
+               ioda::NewDimensionScale<int>("Location", iodaVars->location_),
+               ioda::NewDimensionScale<int>("Channel", iodaVars->channel_)
+         };
+      }
+      ioda::ObsGroup ogrp = ioda::ObsGroup::generate(group, newDims);
 
-        // Create different dimensionScales for data w/wo channel info
-        std::vector<ioda::Variable> dimensionScales {
-            ogrp.vars["Location"]
-        };
-        if (iodaVars.channelValues_(0) > 0) {
-           dimensionScales = {ogrp.vars["Location"], ogrp.vars["Channel"]};
-           ogrp.vars["Channel"].writeWithEigenRegular(iodaVars.channelValues_);
-        }
+      // Create different dimensionScales for data w/wo channel info
+      std::vector<ioda::Variable> dimensionScales {
+          ogrp.vars["Location"]
+      };
+      if (iodaVars->channelValues_(0) > 0) {
+         dimensionScales = {ogrp.vars["Location"], ogrp.vars["Channel"]};
+         ogrp.vars["Channel"].writeWithEigenRegular(iodaVars->channelValues_);
+      }
 
 
-        // Set up the creation parameters
-        ioda::VariableCreationParameters float_params = createVariableParams<float>();
-        ioda::VariableCreationParameters int_params = createVariableParams<int>();
-        ioda::VariableCreationParameters long_params = createVariableParams<int64_t>();
+      // Set up the creation parameters
+      ioda::VariableCreationParameters float_params = createVariableParams<float>();
+      ioda::VariableCreationParameters int_params = createVariableParams<int>();
+      ioda::VariableCreationParameters long_params = createVariableParams<int64_t>();
 
-        // Create the mandatory IODA variables
-        ioda::Variable iodaDatetime =
-          ogrp.vars.createWithScales<int64_t>("MetaData/dateTime",
-                                          {ogrp.vars["Location"]}, long_params);
-        // TODO(MD): Make sure units with iodaVarsAll when applying mpi
-        iodaDatetime.atts.add<std::string>("units", {iodaVars.referenceDate_}, {1});
-        ioda::Variable iodaLat =
-          ogrp.vars.createWithScales<float>("MetaData/latitude",
-                                            {ogrp.vars["Location"]}, float_params);
-        ioda::Variable iodaLon =
-          ogrp.vars.createWithScales<float>("MetaData/longitude",
-                                            {ogrp.vars["Location"]}, float_params);
+      // Create the mandatory IODA variables
+      ioda::Variable iodaDatetime =
+        ogrp.vars.createWithScales<int64_t>("MetaData/dateTime",
+                                        {ogrp.vars["Location"]}, long_params);
+      iodaDatetime.atts.add<std::string>("units", {iodaVars->referenceDate_}, {1});
+      ioda::Variable iodaLat =
+        ogrp.vars.createWithScales<float>("MetaData/latitude",
+                                          {ogrp.vars["Location"]}, float_params);
+      ioda::Variable iodaLon =
+        ogrp.vars.createWithScales<float>("MetaData/longitude",
+                                          {ogrp.vars["Location"]}, float_params);
 
-        ioda::Variable iodaObsVal =
-          ogrp.vars.createWithScales<float>("ObsValue/"+variable_,
-                                            dimensionScales, float_params);
-        ioda::Variable iodaObsErr =
-          ogrp.vars.createWithScales<float>("ObsError/"+variable_,
-                                            dimensionScales, float_params);
+      ioda::Variable iodaObsVal =
+        ogrp.vars.createWithScales<float>("ObsValue/"+variable_,
+                                          dimensionScales, float_params);
+      ioda::Variable iodaObsErr =
+        ogrp.vars.createWithScales<float>("ObsError/"+variable_,
+                                          dimensionScales, float_params);
 
-        ioda::Variable iodaPreQc =
-          ogrp.vars.createWithScales<int>("PreQC/"+variable_,
-                                          dimensionScales, int_params);
+      ioda::Variable iodaPreQc =
+        ogrp.vars.createWithScales<int>("PreQC/"+variable_,
+                                        dimensionScales, int_params);
 
-        // add input filenames to IODA file global attributes
-        ogrp.atts.add<std::string>("obs_source_files", inputFilenames_);
+      // add input filenames to IODA file global attributes
+      ogrp.atts.add<std::string>("obs_source_files", inputFilenames_);
 
-        // add global attributes collected from the specific converter
-        for (const auto& globalAttr : iodaVars.strGlobalAttr_) {
-          ogrp.atts.add<std::string>(globalAttr.first , globalAttr.second);
-        }
+      // add global attributes collected from the specific converter
+      for (const auto& globalAttr : iodaVars->strGlobalAttr_) {
+        ogrp.atts.add<std::string>(globalAttr.first , globalAttr.second);
+      }
 
-        // Create the optional IODA integer metadata
-        ioda::Variable tmpIntMeta;
-        int count = 0;
-        for (const std::string& strMeta : iodaVars.intMetadataName_) {
-          tmpIntMeta = ogrp.vars.createWithScales<int>("MetaData/"+strMeta,
-                                                         {ogrp.vars["Location"]}, int_params);
-          // get ocean basin masks if asked in the config
-          preproc::oceanmask::OceanMask* oceanMask = nullptr;
-          if (fullConfig_.has("ocean basin")) {
-             std::string fileName;
-             fullConfig_.get("ocean basin", fileName);
+      // Create the optional IODA integer metadata
+      ioda::Variable tmpIntMeta;
+      int count = 0;
+      for (const std::string& strMeta : iodaVars->intMetadataName_) {
+        tmpIntMeta = ogrp.vars.createWithScales<int>("MetaData/"+strMeta,
+                                                       {ogrp.vars["Location"]}, int_params);
+        // get ocean basin masks if asked in the config
+        preproc::oceanmask::OceanMask* oceanMask = nullptr;
+        if (fullConfig_.has("ocean basin")) {
+           std::string fileName;
+           fullConfig_.get("ocean basin", fileName);
 
-             // only apply the basin mask if the file exist
-             std::ifstream testFile(fileName.c_str());
-             if (testFile.good()) {
-              oceanMask = new preproc::oceanmask::OceanMask(fileName);
+           // only apply the basin mask if the file exist
+           std::ifstream testFile(fileName.c_str());
+           if (testFile.good()) {
+            oceanMask = new preproc::oceanmask::OceanMask(fileName);
 
-              for (int i = 0; i < iodaVars.location_; i++) {
-                iodaVars.intMetadata_.coeffRef(i, size(iodaVars.intMetadataName_)-1) =
-                  oceanMask->getOceanMask(iodaVars.longitude_[i], iodaVars.latitude_[i]);
-              }
+            for (int i = 0; i < iodaVars->location_; i++) {
+              iodaVars->intMetadata_.coeffRef(i, size(iodaVars->intMetadataName_)-1) =
+                oceanMask->getOceanMask(iodaVars->longitude_[i], iodaVars->latitude_[i]);
             }
           }
-          tmpIntMeta.writeWithEigenRegular(iodaVars.intMetadata_.col(count));
-
-
-          count++;
         }
-
-        // Create the optional IODA float metadata
-        ioda::Variable tmpFloatMeta;
-        count = 0;
-        for (const std::string& strMeta : iodaVars.floatMetadataName_) {
-          tmpFloatMeta = ogrp.vars.createWithScales<float>("MetaData/"+strMeta,
-                                                      {ogrp.vars["Location"]}, float_params);
-          tmpFloatMeta.writeWithEigenRegular(iodaVars.floatMetadata_.col(count));
-          count++;
-        }
-
-        if (iodaVars.originalDatetime_.size() != 0) {
-          ioda::Variable iodaOriginalDatetime =
-              ogrp.vars.createWithScales<int64_t>("MetaData/originalDateTime",
-                                          {ogrp.vars["Location"]}, long_params);
-          iodaOriginalDatetime.writeWithEigenRegular(iodaVars.originalDatetime_);
-          }
-
-
-        // Test output
-        iodaVars.testOutput();
-
-        // Write obs info to group
-        oops::Log::info() << "Writing ioda file" << std::endl;
-        iodaLon.writeWithEigenRegular(iodaVarsAll.longitude_);
-        iodaLat.writeWithEigenRegular(iodaVarsAll.latitude_);
-        iodaDatetime.writeWithEigenRegular(iodaVarsAll.datetime_);
-        iodaObsVal.writeWithEigenRegular(iodaVarsAll.obsVal_);
-        iodaObsErr.writeWithEigenRegular(iodaVarsAll.obsError_);
-        iodaPreQc.writeWithEigenRegular(iodaVarsAll.preQc_);
+        tmpIntMeta.writeWithEigenRegular(iodaVars->intMetadata_.col(count));
+        count++;
       }
+
+      // Create the optional IODA float metadata
+      ioda::Variable tmpFloatMeta;
+      count = 0;
+      for (const std::string& strMeta : iodaVars->floatMetadataName_) {
+        tmpFloatMeta = ogrp.vars.createWithScales<float>("MetaData/"+strMeta,
+                                                    {ogrp.vars["Location"]}, float_params);
+        tmpFloatMeta.writeWithEigenRegular(iodaVars->floatMetadata_.col(count));
+        count++;
+      }
+
+      if (iodaVars->originalDatetime_.size() != 0) {
+        ioda::Variable iodaOriginalDatetime =
+            ogrp.vars.createWithScales<int64_t>("MetaData/originalDateTime",
+                                        {ogrp.vars["Location"]}, long_params);
+        iodaOriginalDatetime.writeWithEigenRegular(iodaVars->originalDatetime_);
+        }
+
+
+      // Test output
+      iodaVars->testOutput();
+
+      // Write obs info to group
+      oops::Log::info() << "Writing ioda file: " << outputFilename << std::endl;
+      iodaLon.writeWithEigenRegular(iodaVars->longitude_);
+      iodaLat.writeWithEigenRegular(iodaVars->latitude_);
+      iodaDatetime.writeWithEigenRegular(iodaVars->datetime_);
+      iodaObsVal.writeWithEigenRegular(iodaVars->obsVal_);
+      iodaObsErr.writeWithEigenRegular(iodaVars->obsError_);
+      iodaPreQc.writeWithEigenRegular(iodaVars->preQc_);
     }
 
 

--- a/utils/preproc/applications/obsprovider2ioda.h
+++ b/utils/preproc/applications/obsprovider2ioda.h
@@ -7,6 +7,7 @@
 #include "oops/runs/Application.h"
 
 #include "../Ghrsst2Ioda.h"
+#include "../IcefbIcesat2Ioda.h"
 #include "../IcecAbi2Ioda.h"
 #include "../IcecAmsr2Ioda.h"
 #include "../IcecJpssrr2Ioda.h"
@@ -57,6 +58,9 @@ namespace obsforge {
         conv2ioda.writeToIoda();
       } else if (provider == "AMSR2") {
         IcecAmsr2Ioda conv2ioda(fullConfig, this->getComm());
+        conv2ioda.writeToIoda();
+      } else if (provider == "FBICESAT2") {
+        IcefbIcesat2Ioda conv2ioda(fullConfig, this->getComm());
         conv2ioda.writeToIoda();
       } else if (provider == "MIRS") {
         IcecMirs2Ioda conv2ioda(fullConfig, this->getComm());

--- a/utils/test/CMakeLists.txt
+++ b/utils/test/CMakeLists.txt
@@ -8,6 +8,7 @@ list( APPEND utils_test_input
   testinput/obsforge_smos2ioda.yaml
   testinput/obsforge_icecabi2ioda.yaml
   testinput/obsforge_icecamsr2ioda.yaml
+  testinput/obsforge_icefbicesat2ioda.yaml
   testinput/obsforge_icecmirs2ioda.yaml
   testinput/obsforge_icecjpssrr2ioda.yaml
   testinput/obsforge_insituall2ioda.yaml
@@ -24,6 +25,7 @@ set( obsforge_utils_test_ref
   testref/smos2ioda.test
   testref/icecabi2ioda.test
   testref/icecamsr2ioda.test
+  testref/icefbicesat2ioda.test
   testref/icecmirs2ioda.test
   testref/icecjpssrr2ioda.test
   testref/insituall2ioda.test
@@ -166,6 +168,14 @@ ecbuild_add_test( TARGET  test_obsforge_util_viirsaod2ioda
 ecbuild_add_test( TARGET  test_obsforge_util_icecamsr2ioda
                   COMMAND ${CMAKE_BINARY_DIR}/bin/obsforge_obsprovider2ioda.x
                   ARGS    "../testinput/obsforge_icecamsr2ioda.yaml"
+                  LIBS    obsforge-utils
+                  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/obsproc
+                  TEST_DEPENDS test_obsforge_util_prepdata)
+
+# Test the ICESat-2 freeboard to IODA converter
+ecbuild_add_test( TARGET  test_obsforge_util_icefbicesat2ioda
+                  COMMAND ${CMAKE_BINARY_DIR}/bin/obsforge_obsprovider2ioda.x
+                  ARGS    "../testinput/obsforge_icefbicesat2ioda.yaml"
                   LIBS    obsforge-utils
                   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/obsproc
                   TEST_DEPENDS test_obsforge_util_prepdata)

--- a/utils/test/prepdata.sh
+++ b/utils/test/prepdata.sh
@@ -37,6 +37,7 @@ cdl2nc4 icec_amsr2_north_1.nc4 ${project_source_dir}/testdata/icec_amsr2_north_1
 cdl2nc4 icec_amsr2_north_2.nc4 ${project_source_dir}/testdata/icec_amsr2_north_2.cdl
 cdl2nc4 icec_amsr2_south_1.nc4 ${project_source_dir}/testdata/icec_amsr2_south_1.cdl
 cdl2nc4 icec_amsr2_south_2.nc4 ${project_source_dir}/testdata/icec_amsr2_south_2.cdl
+cdl2nc4 icefb_icesat2_1.nc4 ${project_source_dir}/testdata/icefb_icesat2_1.cdl
 cdl2nc4 icec_mirs_snpp_1.nc4 ${project_source_dir}/testdata/icec_mirs_snpp_1.cdl
 cdl2nc4 icec_mirs_snpp_2.nc4 ${project_source_dir}/testdata/icec_mirs_snpp_2.cdl
 cdl2nc4 icec_jrr_n20_1.nc4 ${project_source_dir}/testdata/icec_jrr_n20_1.cdl

--- a/utils/test/testdata/icefb_icesat2_1.cdl
+++ b/utils/test/testdata/icefb_icesat2_1.cdl
@@ -1,0 +1,78 @@
+netcdf icefb_icesat2_1 {
+
+// Tiny ATL10-shaped fixture for the ICESat-2 freeboard converter.
+
+group: gt1l {
+  group: freeboard_segment {
+    dimensions:
+      delta_time = 5 ;
+
+    variables:
+      double delta_time(delta_time) ;
+        delta_time:units = "seconds since 2018-01-01 00:00:00" ;
+      double latitude(delta_time) ;
+        latitude:units = "degrees_north" ;
+        latitude:_FillValue = 9.969209968386869e+36 ;
+      double longitude(delta_time) ;
+        longitude:units = "degrees_east" ;
+        longitude:_FillValue = 9.969209968386869e+36 ;
+      float beam_fb_height(delta_time) ;
+        beam_fb_height:units = "m" ;
+        beam_fb_height:_FillValue = 3.4028235e+38f ;
+      float beam_fb_unc(delta_time) ;
+        beam_fb_unc:units = "m" ;
+        beam_fb_unc:_FillValue = 3.4028235e+38f ;
+      int beam_fb_quality_flag(delta_time) ;
+        beam_fb_quality_flag:flag_values = -1, 1, 2, 3, 4, 5 ;
+        beam_fb_quality_flag:flag_meanings = "invalid best high medium low poor" ;
+      float beam_fb_confidence(delta_time) ;
+        beam_fb_confidence:_FillValue = 3.4028235e+38f ;
+
+    data:
+      delta_time = 247190400, 247191000, 247191600, 247192200, 247192800 ;
+      latitude = 82.0, 81.0, -77.0, 70.0, 75.0 ;
+      longitude = 10.0, 20.0, -45.0, 30.0, 40.0 ;
+      beam_fb_height = 0.25f, -0.10f, 0.50f, 6.00f, 0.10f ;
+      beam_fb_unc = 0.05f, 0.10f, 0.20f, 0.30f, 0.05f ;
+      beam_fb_quality_flag = 1, 2, 3, 1, -1 ;
+      beam_fb_confidence = 0.90f, 0.80f, 0.70f, 0.60f, 0.50f ;
+  }
+}
+
+group: gt2r {
+  group: freeboard_segment {
+    dimensions:
+      delta_time = 3 ;
+
+    variables:
+      double delta_time(delta_time) ;
+        delta_time:units = "seconds since 2018-01-01 00:00:00" ;
+      double latitude(delta_time) ;
+        latitude:units = "degrees_north" ;
+        latitude:_FillValue = 9.969209968386869e+36 ;
+      double longitude(delta_time) ;
+        longitude:units = "degrees_east" ;
+        longitude:_FillValue = 9.969209968386869e+36 ;
+      float beam_fb_height(delta_time) ;
+        beam_fb_height:units = "m" ;
+        beam_fb_height:_FillValue = 3.4028235e+38f ;
+      float beam_fb_unc(delta_time) ;
+        beam_fb_unc:units = "m" ;
+        beam_fb_unc:_FillValue = 3.4028235e+38f ;
+      int beam_fb_quality_flag(delta_time) ;
+        beam_fb_quality_flag:flag_values = -1, 1, 2, 3, 4, 5 ;
+        beam_fb_quality_flag:flag_meanings = "invalid best high medium low poor" ;
+      float beam_fb_confidence(delta_time) ;
+        beam_fb_confidence:_FillValue = 3.4028235e+38f ;
+
+    data:
+      delta_time = 247194000, 247191600, 247201200 ;
+      latitude = -72.0, 65.0, -80.0 ;
+      longitude = 130.0, -150.0, 60.0 ;
+      beam_fb_height = -0.25f, 1.10f, 0.30f ;
+      beam_fb_unc = _, 0.40f, 0.10f ;
+      beam_fb_quality_flag = 4, 5, 1 ;
+      beam_fb_confidence = _, 0.40f, 0.90f ;
+  }
+}
+}

--- a/utils/test/testinput/obsforge_icefbicesat2ioda.yaml
+++ b/utils/test/testinput/obsforge_icefbicesat2ioda.yaml
@@ -1,0 +1,15 @@
+provider: FBICESAT2
+window begin: 2025-11-01T00:00:00Z
+window end: 2025-11-01T02:00:00Z
+output file: icefb_icesat2.ioda.nc
+north output file: icefb_icesat2_north.ioda.nc
+south output file: icefb_icesat2_south.ioda.nc
+max freeboard: 5.0
+default obs error: 0.5
+input files:
+- icefb_icesat2_1.nc4
+
+test:
+  reference filename: testref/icefbicesat2ioda.test
+  test output filename: testoutput/icefbicesat2ioda.test
+  float relative tolerance: 1e-6

--- a/utils/test/testref/icefbicesat2ioda.test
+++ b/utils/test/testref/icefbicesat2ioda.test
@@ -1,0 +1,50 @@
+seconds since 1970-01-01T00:00:00Z
+obsVal:
+    Min: -0.1
+    Max: 1.1
+    Sum: 1.25
+obsError:
+    Min: 0.05
+    Max: 0.4
+    Sum: 0.55
+preQc:
+    Min: 1
+    Max: 5
+    Sum: 8
+longitude:
+    Min: -150
+    Max: 20
+    Sum: -120
+latitude:
+    Min: 65
+    Max: 82
+    Sum: 228
+datetime:
+    Min: 1761955200
+    Max: 1761956400
+    Sum: 5285867400
+seconds since 1970-01-01T00:00:00Z
+obsVal:
+    Min: -0.25
+    Max: 0.5
+    Sum: 0.25
+obsError:
+    Min: 0.2
+    Max: 0.5
+    Sum: 0.7
+preQc:
+    Min: 3
+    Max: 4
+    Sum: 7
+longitude:
+    Min: -45
+    Max: 130
+    Sum: 85
+latitude:
+    Min: -77
+    Max: -72
+    Sum: -149
+datetime:
+    Min: 1761956400
+    Max: 1761958800
+    Sum: 3523915200


### PR DESCRIPTION
# Add ICESat-2 Freeboard IODA Converter

## Summary

Adds an ICESat-2 ATL10 freeboard-to-IODA converter and registers it with `obsprovider2ioda` as `FBICESAT2`. The converter reads beam-level freeboard segments, preserves valid negative freeboard values, and writes separate north/south pole output files.

## Changes

- Added `IcefbIcesat2Ioda` converter for ATL10 sea-ice freeboard observations.
- Added configurable freeboard thinning/filtering, quality filtering, default observation error, and per-pole output names.
- Added a focused CTest with a synthetic ATL10-style CDL fixture covering pole splitting, negative freeboard, filtering, and default error handling.

## Testing

Run in the Singularity build container, all listed tests passed.
